### PR TITLE
Polish attention related modules

### DIFF
--- a/docs/code/core.rst
+++ b/docs/code/core.rst
@@ -5,6 +5,52 @@ Core
 ****
 
 
+Attention Mechanism
+===================
+
+:hidden:`AttentionWrapperState`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.core.AttentionWrapperState
+    :members:
+
+:hidden:`LuongAttention`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.core.LuongAttention
+    :members:
+
+:hidden:`BahdanauAttention`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.core.BahdanauAttention
+    :members:
+
+:hidden:`BahdanauMonotonicAttention`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.core.BahdanauMonotonicAttention
+    :members:
+
+:hidden:`LuongMonotonicAttention`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.core.LuongMonotonicAttention
+    :members:
+
+:hidden:`compute_attention`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: texar.core.compute_attention
+
+:hidden:`monotonic_attention`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: texar.core.monotonic_attention
+
+:hidden:`hardmax`
+~~~~~~~~~~~~~~~~~~~
+.. autofunction:: texar.core.hardmax
+
+:hidden:`sparsemax`
+~~~~~~~~~~~~~~~~~~~
+.. autofunction:: texar.core.sparsemax
+
+
+
 Cells
 =====
 

--- a/examples/seq2seq_attn/seq2seq_attn.py
+++ b/examples/seq2seq_attn/seq2seq_attn.py
@@ -68,7 +68,7 @@ class Seq2Seq_Attn(ModuleBase):
         self.decoder = tx.modules.AttentionRNNDecoder(
             encoder_output_size=
             self.encoder.cell_fw.hidden_size+self.encoder.cell_bw.hidden_size,
-            input_size=self.target_embedder.dim + config_model.num_units,
+            input_size=self.target_embedder.dim + config_model.decoder['attention']['attention_layer_size'],
             vocab_size=self.target_vocab_size,
             hparams=config_model.decoder)
 

--- a/examples/seq2seq_attn/seq2seq_attn.py
+++ b/examples/seq2seq_attn/seq2seq_attn.py
@@ -68,7 +68,8 @@ class Seq2Seq_Attn(ModuleBase):
         self.decoder = tx.modules.AttentionRNNDecoder(
             encoder_output_size=
             self.encoder.cell_fw.hidden_size+self.encoder.cell_bw.hidden_size,
-            input_size=self.target_embedder.dim + config_model.decoder['attention']['attention_layer_size'],
+            input_size=self.target_embedder.dim + config_model.decoder
+            ['attention']['attention_layer_size'],
             vocab_size=self.target_vocab_size,
             hparams=config_model.decoder)
 

--- a/stubs/torch/__init__.pyi
+++ b/stubs/torch/__init__.pyi
@@ -40,6 +40,26 @@ def set_grad_enabled(mode: bool) -> ContextManager[None]:
 class device: ...
 
 
+class finfo:
+
+    def __init__(self, type: torch.dtype): ...
+
+    @property
+    def bits(self) -> builtins.int: ...
+
+    @property
+    def eps(self) -> builtins.float: ...
+
+    @property
+    def max(self) -> builtins.float: ...
+
+    @property
+    def min(self) -> builtins.float: ...
+
+    @property
+    def tiny(self) -> builtins.float: ...
+
+
 class layout: ...
 
 

--- a/texar/core/__init__.py
+++ b/texar/core/__init__.py
@@ -18,6 +18,7 @@ Modules of texar core.
 # pylint: disable=wildcard-import
 
 from texar.core.attention_mechanism import *
+from texar.core.attention_mechanism_utils import *
 from texar.core.cell_wrappers import *
 from texar.core.layers import *
 from texar.core.optimization import *

--- a/texar/core/attention_mechanism.py
+++ b/texar/core/attention_mechanism.py
@@ -114,14 +114,14 @@ class _BaseAttentionMechanism(AttentionMechanism):
 
         self._encoder_output_size = encoder_output_size
 
-        self._query: Optional[torch.Tensor] = None
         self._values: Optional[torch.Tensor] = None
         self._keys: Optional[torch.Tensor] = None
 
     def forward(self,  # type: ignore
                 query: torch.Tensor,
                 memory: torch.Tensor,
-                memory_sequence_length: Optional[torch.Tensor] = None):
+                memory_sequence_length: Optional[torch.Tensor] = None
+                ) -> torch.Tensor:
         r"""Preprocess the memory and query.
 
         Args:
@@ -133,7 +133,7 @@ class _BaseAttentionMechanism(AttentionMechanism):
                 masked with zeros for values past the respective sequence
                 lengths.
         """
-        self._query = self.query_layer(query) if self.query_layer else query
+        query = self.query_layer(query) if self.query_layer else query
 
         if self._values is None and self._keys is None:
             self._values = prepare_memory(memory, memory_sequence_length)
@@ -142,6 +142,7 @@ class _BaseAttentionMechanism(AttentionMechanism):
                 self._keys = self.memory_layer(self._values)
             else:
                 self._keys = self._values
+        return query
 
     @property
     def memory_layer(self) -> nn.Module:
@@ -352,11 +353,11 @@ class LuongAttention(_BaseAttentionMechanism):
             ``[batch_size, alignments_size]`` (``alignments_size`` is memory's
             ``max_time``).
         """
-        super().forward(query=query,
-                        memory=memory,
-                        memory_sequence_length=memory_sequence_length)
+        query = super().forward(query=query,
+                                memory=memory,
+                                memory_sequence_length=memory_sequence_length)
 
-        score = _luong_score(self._query,  # type: ignore
+        score = _luong_score(query,  # type: ignore
                              self._keys, self.attention_g)
 
         alignments = self.wrapped_probability_fn(
@@ -501,11 +502,11 @@ class BahdanauAttention(_BaseAttentionMechanism):
             ``[batch_size, alignments_size]`` (``alignments_size`` is memory's
             ``max_time``).
         """
-        super().forward(query=query,
-                        memory=memory,
-                        memory_sequence_length=memory_sequence_length)
+        query = super().forward(query=query,
+                                memory=memory,
+                                memory_sequence_length=memory_sequence_length)
 
-        score = _bahdanau_score(self._query,  # type: ignore
+        score = _bahdanau_score(query,  # type: ignore
                                 self._keys,
                                 self.attention_v,
                                 self.attention_g,
@@ -798,11 +799,11 @@ class BahdanauMonotonicAttention(_BaseMonotonicAttentionMechanism):
             ``[batch_size, alignments_size]`` (``alignments_size`` is memory's
             ``max_time``).
         """
-        super().forward(query=query,
-                        memory=memory,
-                        memory_sequence_length=memory_sequence_length)
+        query = super().forward(query=query,
+                                memory=memory,
+                                memory_sequence_length=memory_sequence_length)
 
-        score = _bahdanau_score(self._query,  # type: ignore
+        score = _bahdanau_score(query,  # type: ignore
                                 self._keys,
                                 self.attention_v,
                                 self.attention_g,
@@ -902,11 +903,11 @@ class LuongMonotonicAttention(_BaseMonotonicAttentionMechanism):
             ``[batch_size, alignments_size]`` (``alignments_size`` is memory's
             ``max_time``).
         """
-        super().forward(query=query,
-                        memory=memory,
-                        memory_sequence_length=memory_sequence_length)
+        query = super().forward(query=query,
+                                memory=memory,
+                                memory_sequence_length=memory_sequence_length)
 
-        score = _luong_score(self._query,  # type: ignore
+        score = _luong_score(query,  # type: ignore
                              self._keys, self.attention_g)
         score += self.attention_score_bias
 

--- a/texar/core/attention_mechanism_test.py
+++ b/texar/core/attention_mechanism_test.py
@@ -30,6 +30,7 @@ class AttentionMechanismTest(unittest.TestCase):
     def test_LuongAttention(self):
         r"""Tests `LuongAttention`
         """
+        # Case 1
         attention_mechanism = LuongAttention(
             num_units=self._attention_dim,
             encoder_output_size=self._encoder_output_size)
@@ -53,6 +54,7 @@ class AttentionMechanismTest(unittest.TestCase):
             [self._batch_size, self._max_time]))
         self.assertEqual(len(attention_mechanism.trainable_variables), 1)
 
+        # Case 2
         attention_mechanism = LuongAttention(
             num_units=self._attention_dim,
             encoder_output_size=self._encoder_output_size,
@@ -80,9 +82,10 @@ class AttentionMechanismTest(unittest.TestCase):
     def test_BahdanauAttention(self):
         r"""Tests BahdanauAttention
         """
+        # Case 1
         attention_mechanism = BahdanauAttention(
             num_units=self._attention_dim,
-            cell_output_size=128,
+            decoder_output_size=128,
             encoder_output_size=self._encoder_output_size)
 
         cell_output = torch.rand(self._batch_size, 128)
@@ -104,9 +107,10 @@ class AttentionMechanismTest(unittest.TestCase):
             [self._batch_size, self._max_time]))
         self.assertEqual(len(attention_mechanism.trainable_variables), 3)
 
+        # Case 2
         attention_mechanism = BahdanauAttention(
             num_units=self._attention_dim,
-            cell_output_size=128,
+            decoder_output_size=128,
             encoder_output_size=self._encoder_output_size,
             normalize=True)
 
@@ -132,6 +136,7 @@ class AttentionMechanismTest(unittest.TestCase):
     def test_LuongMonotonicAttention(self):
         r"""Tests LuongMonotonicAttention
         """
+        # Case 1
         attention_mechanism = LuongMonotonicAttention(
             num_units=self._attention_dim,
             encoder_output_size=self._encoder_output_size)
@@ -155,6 +160,7 @@ class AttentionMechanismTest(unittest.TestCase):
             [self._batch_size, self._max_time]))
         self.assertEqual(len(attention_mechanism.trainable_variables), 2)
 
+        # Case 2
         attention_mechanism = LuongMonotonicAttention(
             num_units=self._attention_dim,
             encoder_output_size=self._encoder_output_size,
@@ -182,9 +188,10 @@ class AttentionMechanismTest(unittest.TestCase):
     def test_BahdanauMonotonicAttention(self):
         r"""Tests BahdanauMonotonicAttention
         """
+        # Case 1
         attention_mechanism = BahdanauMonotonicAttention(
             num_units=self._attention_dim,
-            cell_output_size=128,
+            decoder_output_size=128,
             encoder_output_size=self._encoder_output_size)
 
         cell_output = torch.rand(self._batch_size, 128)
@@ -206,9 +213,10 @@ class AttentionMechanismTest(unittest.TestCase):
             [self._batch_size, self._max_time]))
         self.assertEqual(len(attention_mechanism.trainable_variables), 4)
 
+        # Case 2
         attention_mechanism = BahdanauMonotonicAttention(
             num_units=self._attention_dim,
-            cell_output_size=128,
+            decoder_output_size=128,
             encoder_output_size=self._encoder_output_size,
             normalize=True)
 

--- a/texar/core/attention_mechanism_utils.py
+++ b/texar/core/attention_mechanism_utils.py
@@ -1,0 +1,225 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Various helper utilities for attention mechanism.
+
+The implementation of sparsemax adapted from:
+    `https://github.com/OpenNMT/OpenNMT-py/blob/master/onmt/
+    modules/sparse_activations.py`
+"""
+
+# pylint: disable=too-many-arguments, too-many-instance-attributes
+# pylint: disable=missing-docstring  # does not support generic classes
+
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.autograd import Function
+
+from texar.utils.utils import sequence_mask
+
+
+__all__ = [
+    'hardmax',
+    'maybe_mask_score',
+    'prepare_memory',
+    'safe_cumprod',
+    'sparsemax',
+]
+
+
+def hardmax(logits: torch.Tensor) -> torch.Tensor:
+    r"""Returns batched one-hot vectors. The depth index containing
+    the `1` is that of the maximum logit value.
+
+    Args:
+        logits: A batch tensor of logit values.
+
+    Returns:
+        A batched one-hot tensor.
+    """
+    if not isinstance(logits, torch.Tensor):
+        logits = torch.tensor(logits)
+    depth = logits.shape[-1]
+    one_hot = torch.eye(depth, dtype=torch.int64)
+    return F.embedding(torch.argmax(logits, -1), one_hot)
+
+
+def maybe_mask_score(score: torch.Tensor,
+                     score_mask_value: torch.Tensor,
+                     memory_sequence_length: Optional[torch.LongTensor]) \
+        -> torch.Tensor:
+    r"""Mask the attention score based on the masks."""
+    if memory_sequence_length is None:
+        return score
+
+    for memory_sequence_length_value in memory_sequence_length:
+        if memory_sequence_length_value <= 0:
+            raise ValueError(
+                "All values in memory_sequence_length must be greater "
+                "than zero.")
+
+    score_mask = sequence_mask(memory_sequence_length,
+                               max_len=score.shape[1])
+    score_mask_values = score_mask_value * torch.ones_like(score)
+    return torch.where(score_mask, score, score_mask_values)
+
+
+def prepare_memory(memory: torch.Tensor,
+                   memory_sequence_length: Optional[torch.LongTensor]) \
+        -> torch.Tensor:
+    r"""Convert to tensor and possibly mask ``memory``.
+
+    Args:
+        memory: tensor, shaped ``[batch_size, max_time, ...]``.
+        memory_sequence_length: integer tensor, shaped ``[batch_size]``.
+
+    Returns:
+        A (possibly masked), new ``memory``.
+
+    Raises:
+        ValueError: if ``memory`` and ``memory_sequence_length`` do not have
+        the same ``batch_size``.
+    """
+    if (memory_sequence_length is not None and
+            not isinstance(memory_sequence_length, torch.Tensor)):
+        memory_sequence_length = torch.tensor(memory_sequence_length,
+                                              dtype=torch.long)
+
+    if memory_sequence_length is None:
+        seq_len_mask = None
+    else:
+        seq_len_mask = sequence_mask(memory_sequence_length,
+                                     max_len=memory.shape[1],
+                                     dtype=memory.dtype)
+        seq_len_batch_size = memory_sequence_length.shape[0]
+
+    # Mask the memory based on the memory mask.
+    rank = memory.dim()
+    extra_ones = [1] * (rank - 2)
+    m_batch_size = memory.shape[0]
+
+    if seq_len_mask is not None:
+        if seq_len_batch_size != m_batch_size:
+            raise ValueError("memory_sequence_length and memory tensor "
+                             "batch sizes do not match.")
+        seq_len_mask = torch.reshape(
+            seq_len_mask,
+            tuple(list(seq_len_mask.shape) + extra_ones))
+        return memory * seq_len_mask
+    else:
+        return memory
+
+
+def safe_cumprod(x: torch.Tensor,
+                 *args,
+                 **kwargs) -> torch.Tensor:
+    r"""Computes cumprod of x in logspace using cumsum to avoid underflow.
+    The cumprod function and its gradient can result in numerical
+    instabilities when its argument has very small and/or zero values.
+    As long as the argument is all positive, we can instead compute the
+    cumulative product as `exp(cumsum(log(x)))`.  This function can be called
+    identically to :torch:`cumprod`.
+
+    Args:
+        x: Tensor to take the cumulative product of.
+        *args: Passed on to cumsum; these are identical to those in cumprod.
+        **kwargs: Passed on to cumsum; these are identical to those in cumprod.
+
+    Returns:
+        Cumulative product of x.
+    """
+    if not isinstance(x, torch.Tensor):
+        x = torch.tensor(x)
+
+    type_map = {torch.float16: np.float16,
+                torch.float32: np.float32,
+                torch.float64: np.float64}
+
+    tiny = np.finfo(type_map[x.dtype]).tiny
+    return torch.exp(torch.cumsum(torch.log(torch.clamp(x, tiny, 1)),
+                                  *args, **kwargs))
+
+
+def _make_ix_like(input: torch.Tensor,
+                  dim: int = -1) -> torch.Tensor:
+    d = input.size(dim)
+    rho = torch.arange(1, d + 1, device=input.device, dtype=input.dtype)
+    view = [1] * input.dim()
+    view[0] = -1
+    return rho.view(tuple(view)).transpose(0, dim)
+
+
+def _threshold_and_support(input: torch.Tensor,
+                           dim: int = -1) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Sparsemax building block: compute the threshold
+
+    Args:
+        input: any dimension
+        dim: dimension along which to apply the sparsemax
+
+    Returns:
+        the threshold value
+    """
+
+    input_srt, _ = torch.sort(input, descending=True, dim=dim)
+    input_cumsum = input_srt.cumsum(dim) - 1
+    rhos = _make_ix_like(input, dim)
+    support = rhos * input_srt > input_cumsum
+
+    support_size = support.sum(dim=dim).unsqueeze(dim)
+    tau = input_cumsum.gather(dim, support_size - 1)
+    tau /= support_size.to(input.dtype)
+    return tau, support_size
+
+
+class SparsemaxFunction(Function):
+
+    @staticmethod
+    def forward(ctx,  # type: ignore
+                input: torch.Tensor,
+                dim: int = -1) -> torch.Tensor:
+        r"""sparsemax: normalizing sparse transform (a la softmax)
+
+        Args:
+            input (Tensor): any shape
+            dim: dimension along which to apply sparsemax
+
+        Returns:
+            output (Tensor): same shape as input
+        """
+        ctx.dim = dim
+        max_val, _ = input.max(dim=dim, keepdim=True)
+        input -= max_val  # same numerical stability trick as for softmax
+        tau, supp_size = _threshold_and_support(input, dim=dim)
+        output = torch.clamp(input - tau, min=0)
+        ctx.save_for_backward(supp_size, output)
+        return output
+
+    @staticmethod
+    def backward(ctx,  # type: ignore
+                 grad_output: torch.Tensor) -> Tuple[torch.Tensor, None]:
+        supp_size, output = ctx.saved_tensors
+        dim = ctx.dim
+        grad_input = grad_output.clone()
+        grad_input[output == 0] = 0
+
+        v_hat = grad_input.sum(dim=dim) / supp_size.to(output.dtype).squeeze()
+        v_hat = v_hat.unsqueeze(dim)
+        grad_input = torch.where(output != 0, grad_input - v_hat, grad_input)
+        return grad_input, None
+
+
+sparsemax = SparsemaxFunction.apply  # type: ignore

--- a/texar/core/attention_mechanism_utils.py
+++ b/texar/core/attention_mechanism_utils.py
@@ -29,7 +29,6 @@ from torch.autograd import Function
 
 from texar.utils.utils import sequence_mask
 
-
 __all__ = [
     'hardmax',
     'maybe_mask_score',
@@ -114,7 +113,8 @@ def prepare_memory(memory: torch.Tensor,
         if seq_len_batch_size != m_batch_size:
             raise ValueError("memory_sequence_length and memory tensor "
                              "batch sizes do not match.")
-        return memory * seq_len_mask.view(seq_len_mask.size() + (1,)*(rank - 2))
+        return memory * seq_len_mask.view(
+            seq_len_mask.size() + (1,) * (rank - 2))
     else:
         return memory
 
@@ -183,15 +183,6 @@ class SparsemaxFunction(Function):
     def forward(ctx,  # type: ignore
                 input: torch.Tensor,
                 dim: int = -1) -> torch.Tensor:
-        r"""sparsemax: normalizing sparse transform (a la softmax)
-
-        Args:
-            input (Tensor): any shape
-            dim: dimension along which to apply sparsemax
-
-        Returns:
-            output (Tensor): same shape as input
-        """
         ctx.dim = dim
         max_val, _ = input.max(dim=dim, keepdim=True)
         input -= max_val  # same numerical stability trick as for softmax
@@ -214,4 +205,14 @@ class SparsemaxFunction(Function):
         return grad_input, None
 
 
-sparsemax = SparsemaxFunction.apply  # type: ignore
+def sparsemax(input: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    r"""sparsemax: normalizing sparse transform (a la softmax)
+
+    Args:
+        input (Tensor): A batch tensor of logit values.
+        dim: Dimension along which to apply sparsemax.
+
+    Returns:
+        Tensor: output with the same shape as input.
+    """
+    return SparsemaxFunction.apply(input, dim)  # type: ignore

--- a/texar/core/attention_mechanism_utils_test.py
+++ b/texar/core/attention_mechanism_utils_test.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for attention mechanism utils.
+"""
+
+import unittest
+
+import torch
+
+import texar
+
+
+class AttentionMechanismUtilsTest(unittest.TestCase):
+    r"""Tests attention mechanism utils.
+    """
+
+    def test_prepare_memory(self):
+        r"""Tests `texar.core.attention_mechanism_utils.prepare_memory`.
+        """
+        memory = torch.tensor([[[1, 2, 3], [4, 5, 6], [7, 8, 9], [9, 8, 7]],
+                               [[3, 2, 1], [6, 5, 4], [9, 8, 7], [4, 5, 6]]])
+        memory_sequence_length = torch.tensor([3, 2])
+        masked_memory = texar.core.prepare_memory(memory,
+                                                  memory_sequence_length)
+
+        expected_memory = [[[1, 2, 3], [4, 5, 6], [7, 8, 9], [0, 0, 0]],
+                           [[3, 2, 1], [6, 5, 4], [0, 0, 0], [0, 0, 0]]]
+
+        self.assertEqual(masked_memory.tolist(), expected_memory)
+
+    def test_maybe_mask_score(self):
+        r"""Tests `texar.core.attention_mechanism_utils.maybe_mask_score`.
+        """
+        score = torch.tensor([[1, 2, 3],
+                              [4, 5, 6],
+                              [7, 8, 9]])
+        score_mask_value = torch.tensor(-1)
+        memory_sequence_length = torch.tensor([1, 2, 3])
+        masked_score = texar.core.maybe_mask_score(score, score_mask_value,
+                                                   memory_sequence_length)
+
+        expected_score = [[1, -1, -1], [4, 5, -1], [7, 8, 9]]
+
+        self.assertEqual(masked_score.tolist(), expected_score)
+
+    def test_hardmax(self):
+        r"""Tests `texar.core.attention_mechanism_utils.hardmax`.
+        """
+        logits = torch.tensor([[[1, 2, 3], [4, 5, 6], [7, 8, 9], [9, 8, 7]],
+                               [[3, 2, 1], [6, 5, 4], [9, 8, 7], [4, 5, 6]]])
+        outputs = texar.core.hardmax(logits)
+
+        expected_outputs = [[[0, 0, 1], [0, 0, 1], [0, 0, 1], [1, 0, 0]],
+                            [[1, 0, 0], [1, 0, 0], [1, 0, 0], [0, 0, 1]]]
+
+        self.assertEqual(outputs.tolist(), expected_outputs)
+
+    def test_sparsemax(self):
+        r"""Tests `texar.core.attention_mechanism_utils.sparsemax`.
+        """
+        logits = torch.tensor([[1.2, 3.2, 0.1, 4.3, 5.0],
+                               [3.3, 4.6, 9.5, 5.4, 8.7]])
+        outputs = texar.core.sparsemax(logits)
+
+        expected_outputs = [[0.0, 0.0, 0.0, 0.1500001, 0.8499999],
+                            [0.0, 0.0, 0.8999996, 0.0, 0.09999943]]
+
+        outputs = outputs.tolist()
+        for i in range(2):
+            for j in range(5):
+                self.assertAlmostEqual(outputs[i][j],
+                                       expected_outputs[i][j],
+                                       places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/texar/core/attention_mechanism_utils_test.py
+++ b/texar/core/attention_mechanism_utils_test.py
@@ -54,6 +54,18 @@ class AttentionMechanismUtilsTest(unittest.TestCase):
 
         self.assertEqual(outputs.tolist(), expected_outputs)
 
+    def test_safe_cumprod(self):
+        r"""Tests `texar.core.attention_mechanism_utils.safe_cumprod`.
+        """
+        x = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5])
+        outputs = texar.core.safe_cumprod(x, dim=0)
+
+        expected_outputs = [0.1, 0.02, 0.006, 0.0024, 0.0012]
+
+        outputs = outputs.tolist()
+        for i in range(5):
+            self.assertAlmostEqual(outputs[i], expected_outputs[i])
+
     def test_sparsemax(self):
         r"""Tests `texar.core.attention_mechanism_utils.sparsemax`.
         """

--- a/texar/core/cell_wrappers.py
+++ b/texar/core/cell_wrappers.py
@@ -703,8 +703,8 @@ class AttentionWrapper(RNNCellBase[AttentionWrapperState]):
                 attention_mechanism=attention_mechanism,
                 cell_output=cell_output,
                 attention_state=attention_state,
-                attention_layer=self._attention_layers[i] if
-                self._attention_layers else None,
+                attention_layer=(self._attention_layers[i]
+                                 if self._attention_layers else None),
                 memory=memory,
                 memory_sequence_length=memory_sequence_length)
 

--- a/texar/core/cell_wrappers.py
+++ b/texar/core/cell_wrappers.py
@@ -601,7 +601,7 @@ class AttentionWrapper(RNNCellBase[AttentionWrapperState]):
 
         Returns:
             An :class:`~texar.core.AttentionWrapperState` tuple containing
-            zeroed out tensors and, possibly, empty `TensorArray` objects.
+            zeroed out tensors and Python lists.
         """
         cell_state: torch.Tensor = super().zero_state(batch_size)  # type:ignore
 
@@ -708,8 +708,7 @@ class AttentionWrapper(RNNCellBase[AttentionWrapperState]):
                 memory=memory,
                 memory_sequence_length=memory_sequence_length)
 
-            if (self._alignment_history and
-                    previous_alignment_history is not None):
+            if self._alignment_history:
                 alignment_history = previous_alignment_history[i] + [alignments]
             else:
                 alignment_history = previous_alignment_history[i]

--- a/texar/modules/decoders/rnn_decoders.py
+++ b/texar/modules/decoders/rnn_decoders.py
@@ -630,10 +630,9 @@ class AttentionRNNDecoder(RNNDecoderBase[AttentionWrapperState,
         self.memory = None
         self.memory_sequence_length = None
 
-        # Release memory and memory_sequence_length in AttentionMechanism
+        # Release the cached memory in AttentionMechanism
         for attention_mechanism in self._cell._attention_mechanisms:
-            attention_mechanism._values = None
-            attention_mechanism._keys = None
+            attention_mechanism.clear_cache()
 
         return outputs, final_state, sequence_lengths
 

--- a/texar/modules/decoders/rnn_decoders_test.py
+++ b/texar/modules/decoders/rnn_decoders_test.py
@@ -230,8 +230,7 @@ class AttentionRNNDecoderTest(unittest.TestCase):
             },
             "attention": {
                 "kwargs": {
-                    "num_units": self._attention_dim,
-                    "encoder_output_size": 64
+                    "num_units": self._attention_dim
                 },
             }
         }
@@ -247,8 +246,7 @@ class AttentionRNNDecoderTest(unittest.TestCase):
             },
             "attention": {
                 "kwargs": {
-                    "num_units": self._attention_dim,
-                    "encoder_output_size": 64
+                    "num_units": self._attention_dim
                 },
             }
         }
@@ -265,8 +263,7 @@ class AttentionRNNDecoderTest(unittest.TestCase):
             },
             "attention": {
                 "kwargs": {
-                    "num_units": self._attention_dim,
-                    "encoder_output_size": 64
+                    "num_units": self._attention_dim
                 },
             }
         }


### PR DESCRIPTION
1. polish and simplify the attention related modules.
2. move `attention_mechanism` related utils to `attention_mechanism_utils`.
3. add `sparsemax` in `attention_mechanism_utils` which can be used as the `probability_fn` in `LuongAttention` and `BahdanauAttention`.
4. add `attention_mechanism_utils_test`
5. For each batch of the input sequence, we only need to preprocess `memory` once (Add line 633 in `rnn_decoder.py`).