### PR TITLE
Handle prepend logic to keys in MultiAlignedData's collate function

### DIFF
--- a/texar/data/data/multi_aligned_data.py
+++ b/texar/data/data/multi_aligned_data.py
@@ -223,6 +223,8 @@ class MultiAlignedData(
                 for key in text_hparams["dataset"].keys():
                     if key in hparams_i:
                         text_hparams["dataset"][key] = hparams_i[key]
+                # handle prepend logic in MultiAlignedData collate function
+                text_hparams["dataset"]["data_name"] = None
 
                 self._databases.append(
                     MonoTextData._construct(hparams=text_hparams,
@@ -488,7 +490,8 @@ class MultiAlignedData(
         batch: Dict[str, Any] = {}
         for i, transposed_example in enumerate(transposed_examples):
             kth_batch = self._databases[i].collate(transposed_example)
-            batch.update(kth_batch._batch)
+            for key, _ in self._names[i].items():
+                batch.update({self._names[i][key]: kth_batch[key]})
         return Batch(len(examples), batch=batch)
 
     def list_items(self):
@@ -557,4 +560,4 @@ class MultiAlignedData(
         i = self._maybe_name_to_id(name_or_id)
         if not _is_scalar_data(self._hparams.datasets[i]["data_type"]):
             return None
-        return self._names[i]
+        return self._names[i]["label"]

--- a/texar/data/data/multi_aligned_data.py
+++ b/texar/data/data/multi_aligned_data.py
@@ -490,8 +490,8 @@ class MultiAlignedData(
         batch: Dict[str, Any] = {}
         for i, transposed_example in enumerate(transposed_examples):
             kth_batch = self._databases[i].collate(transposed_example)
-            for key, _ in self._names[i].items():
-                batch.update({self._names[i][key]: kth_batch[key]})
+            for key, name in self._names[i].items():
+                batch.update({name: kth_batch[key]})
         return Batch(len(examples), batch=batch)
 
     def list_items(self):

--- a/texar/data/data/record_data.py
+++ b/texar/data/data/record_data.py
@@ -343,10 +343,6 @@ class RecordData(DataBase[Dict[str, Any], Dict[str, Any]]):
 
         self._other_transforms = self._hparams.dataset.other_transformations
 
-        data_name = self._hparams.dataset.data_name
-        self._items = {key: connect_name(data_name, key)
-                       for key, _ in self._features.items()}
-
         data_source = PickleDataSource(self._hparams.dataset.files)
 
         super().__init__(data_source, hparams)
@@ -635,7 +631,7 @@ class RecordData(DataBase[Dict[str, Any], Dict[str, Any]]):
             else:
                 # VarLenFeature, just put everything in a Python list.
                 pass
-            batch[self._items[key]] = values
+            batch[key] = values
         return Batch(len(examples), batch)
 
     def list_items(self) -> List[str]:
@@ -644,7 +640,7 @@ class RecordData(DataBase[Dict[str, Any], Dict[str, Any]]):
         Returns:
             A list of strings.
         """
-        return list(self._items.keys())
+        return list(self._features.keys())
 
     @property
     def feature_names(self):


### PR DESCRIPTION
This PR

- Avoids prepending `data_name` to keys in RecordData
- Handles prepend logic for keys inside `MultiAlignedData`'s `collate` function instead of in individual components' `collate` function

This PR should fix the `input_ids` KeyError mentioned in https://github.com/asyml/texar-pytorch/issues/62.