### PR TITLE
Make MergeLayer._layers to be nn.ModuleList variable 

### DIFF
--- a/texar/core/layers.py
+++ b/texar/core/layers.py
@@ -635,12 +635,12 @@ class MergeLayer(nn.Module):
         self._mode = mode
         self._dim = dim
 
-        self._layers: Optional[List[nn.Module]] = None
+        self._layers: Optional[nn.ModuleList] = None
         if layers is not None:
             if len(layers) == 0:
                 raise ValueError(
                     "'layers' must be either None or a non-empty list.")
-            self._layers = []
+            self._layers = nn.ModuleList()
             for layer in layers:
                 if isinstance(layer, nn.Module):
                     self._layers.append(layer)
@@ -704,7 +704,7 @@ class MergeLayer(nn.Module):
         return outputs
 
     @property
-    def layers(self) -> Optional[List[nn.Module]]:
+    def layers(self) -> Optional[nn.ModuleList]:
         r"""The list of parallel layers.
         """
         return self._layers


### PR DESCRIPTION
This PR

- Makes `self._layers` of `MergeLayer` a `nn.ModuleList` variable

This fixes https://github.com/asyml/texar-pytorch/issues/72