### PR TITLE
Fix MergeOp when using reduce pooling ops

### DIFF
--- a/texar/core/layers.py
+++ b/texar/core/layers.py
@@ -690,7 +690,7 @@ class MergeLayer(nn.Module):
         # In case of reduce pooling operations, feature dim is removed and
         # channel dim is merged.
         # In non-reduce pooling operations, feature dim is merged.
-        dim = self._dim if self._dim is not None else - 1
+        dim = self._dim if self._dim is not None else -1
 
         if self._mode == 'concat':
             outputs = torch.cat(tensors=layer_outputs, dim=dim)

--- a/texar/core/layers_test.py
+++ b/texar/core/layers_test.py
@@ -143,6 +143,12 @@ class MergeLayerTest(unittest.TestCase):
         output = m_layer(input)
         self.assertEqual(output.shape, torch.Size([32, 32, 149]))
 
+    def test_empty_merge_layer(self):
+        m_layer = layers.MergeLayer(layers=None)
+        input = torch.randn(32, 32, 10)
+        output = m_layer(input)
+        self.assertEqual(torch.all(torch.eq(output, input)), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/texar/core/layers_test.py
+++ b/texar/core/layers_test.py
@@ -104,9 +104,9 @@ class ReducePoolingLayerTest(unittest.TestCase):
         pool_layer = layers.MaxReducePool1d()
         inputs = torch.randn(self._batch_size, self._emb_dim, self._seq_length)
         output = pool_layer(inputs)
-        output_reduce, _ = torch.max(inputs, dim=2, keepdim=True)
+        output_reduce, _ = torch.max(inputs, dim=2)
         self.assertEqual(output.shape, torch.Size([self._batch_size,
-                                                   self._emb_dim, 1]))
+                                                   self._emb_dim]))
         self.assertEqual(torch.all(torch.eq(output, output_reduce)), 1)
 
     def test_average_reduce_pooling_layer(self):
@@ -115,9 +115,9 @@ class ReducePoolingLayerTest(unittest.TestCase):
         pool_layer = layers.AvgReducePool1d()
         inputs = torch.randn(self._batch_size, self._emb_dim, self._seq_length)
         output = pool_layer(inputs)
-        output_reduce = torch.mean(inputs, dim=2, keepdim=True)
+        output_reduce = torch.mean(inputs, dim=2)
         self.assertEqual(output.shape, torch.Size([self._batch_size,
-                                                   self._emb_dim, 1]))
+                                                   self._emb_dim]))
         self.assertEqual(torch.all(torch.eq(output, output_reduce)), 1)
 
 

--- a/texar/modules/networks/conv_networks_test.py
+++ b/texar/modules/networks/conv_networks_test.py
@@ -67,6 +67,38 @@ class Conv1DNetworkTest(unittest.TestCase):
         outputs_2 = network_2(inputs_2)
         self.assertEqual(outputs_2.shape, torch.Size([128, 10]))
 
+        # test whether concatenation happens along channel dim when feature dim
+        # has been reduced
+        hparams = {
+            # Conv layers
+            "num_conv_layers": 1,
+            "out_channels": 128,
+            "kernel_size": [3, 4, 5],
+            "other_conv_kwargs": {"padding": 0},
+            # Pooling layers
+            "pooling": "AvgPool1d",
+            "pool_size": None,
+            "pool_stride": 1,
+            # Dense layers
+            "num_dense_layers": 0,
+            "out_features": [],
+            "dense_activation": "ReLU",
+            "other_dense_kwargs": None,
+            # Dropout
+            "dropout_conv": [],
+            "dropout_dense": []
+        }
+
+        network_3 = Conv1DNetwork(in_channels=inputs_2.shape[1],
+                                  in_features=inputs_2.shape[2],
+                                  hparams=hparams)
+        inputs_3 = inputs_2
+        outputs_3 = network_3(inputs_3)
+        num_of_kernels = len(hparams["kernel_size"])
+        out_channels = hparams["out_channels"]
+        self.assertEqual(outputs_3.shape,
+                         torch.Size([128, num_of_kernels * out_channels]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR

- Fixes a bug during merging of convolutional layers. Specifically, when reduce pooling operations are used, the feature dim is removed and hence merging happens along channel dim
- Adds a test case in `Conv1DNetworkTest` to verify the above behavior.
- Tests the output of `MergeLayer` for all modes

This fixes https://github.com/asyml/texar-pytorch/issues/44