### PR TITLE
Add cache_embeddings option for SinusoidsPositionEmbedding

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -55,3 +55,4 @@ PyTorch
 pytorch
 torch
 fastly
+precompute

--- a/texar/modules/embedders/embedder_utils.py
+++ b/texar/modules/embedders/embedder_utils.py
@@ -185,7 +185,4 @@ def soft_embedding_lookup(embedding, soft_ids):
         soft_seq_emb = soft_embedding_lookup(
             embedding, softmax(decoder_outputs.logits))
     """
-    return torch.tensordot(
-        soft_ids.type(torch.float),
-        embedding,
-        dims=([-1], [0]))
+    return torch.tensordot(soft_ids, embedding, dims=([-1], [0]))

--- a/texar/modules/embedders/embedder_utils_test.py
+++ b/texar/modules/embedders/embedder_utils_test.py
@@ -17,8 +17,8 @@ class GetEmbeddingTest(unittest.TestCase):
         """
         vocab_size = 100
         emb = embedder_utils.get_embedding(num_embeds=vocab_size)
-        self.assertEqual(emb.shape[0], vocab_size)
-        self.assertEqual(emb.shape[1],
+        self.assertEqual(emb.size(0), vocab_size)
+        self.assertEqual(emb.size(1),
                          embedder_utils.default_embedding_hparams()["dim"])
 
         hparams = {
@@ -29,8 +29,8 @@ class GetEmbeddingTest(unittest.TestCase):
         }
         emb = embedder_utils.get_embedding(
             hparams=hparams, num_embeds=vocab_size, )
-        self.assertEqual(emb.shape[0], vocab_size)
-        self.assertEqual(emb.shape[1],
+        self.assertEqual(emb.size(0), vocab_size)
+        self.assertEqual(emb.size(1),
                          embedder_utils.default_embedding_hparams()["dim"])
 
 

--- a/texar/modules/embedders/embedders_test.py
+++ b/texar/modules/embedders/embedders_test.py
@@ -23,29 +23,29 @@ class EmbedderTest(unittest.TestCase):
         embedder = WordEmbedder(
             vocab_size=100, hparams=hparams)
 
-        inputs = torch.ones([64, 16], dtype=torch.int32)
+        inputs = torch.randint(embedder.vocab_size, (64, 16), dtype=torch.long)
         outputs = embedder(inputs)
 
-        inputs_soft = torch.ones(
-            [64, 16, embedder.vocab_size], dtype=torch.float32)
+        inputs_soft = torch.randn(
+            (64, 16, embedder.vocab_size), dtype=torch.float32)
         outputs_soft = embedder(soft_ids=inputs_soft)
 
-        emb_dim = embedder.dim
-        if isinstance(emb_dim, int):
-            emb_dim = [emb_dim]
-        if not isinstance(emb_dim, (list)):
-            emb_dim = list(emb_dim)
+        if isinstance(embedder.dim, (list, tuple)):
+            emb_dim = tuple(embedder.dim)
+        else:
+            emb_dim = (embedder.dim,)
 
-        hparams_dim = hparams["dim"]
-        if not isinstance(hparams["dim"], (list, tuple)):
-            hparams_dim = [hparams["dim"]]
+        if isinstance(hparams["dim"], (list, tuple)):
+            hparams_dim = tuple(hparams["dim"])
+        else:
+            hparams_dim = (hparams["dim"],)
 
-        self.assertEqual(list(outputs.shape), [64, 16] + emb_dim)
-        self.assertEqual(list(outputs_soft.shape), [64, 16] + emb_dim)
+        self.assertEqual(outputs.size(), (64, 16) + emb_dim)
+        self.assertEqual(outputs_soft.size(), (64, 16) + emb_dim)
         self.assertEqual(emb_dim, hparams_dim)
         self.assertEqual(embedder.vocab_size, 100)
-        self.assertEqual(tuple(outputs.shape), (64, 16) + tuple(emb_dim))
-        self.assertEqual(tuple(outputs_soft.shape), (64, 16) + tuple(emb_dim))
+        self.assertEqual(outputs.size(), (64, 16) + emb_dim)
+        self.assertEqual(outputs_soft.size(), (64, 16) + emb_dim)
 
     def _test_position_embedder(self, hparams):
         """Tests :class:`texar.modules.PositionEmbedder`.
@@ -53,44 +53,52 @@ class EmbedderTest(unittest.TestCase):
         pos_size = 100
         embedder = PositionEmbedder(
             position_size=pos_size, hparams=hparams)
-        inputs = torch.ones([64, 16], dtype=torch.int32)
+        inputs = torch.randint(embedder.num_embeds, (64, 16), dtype=torch.long)
         outputs = embedder(inputs)
 
-        emb_dim = embedder.dim
-        if isinstance(emb_dim, int):
-            emb_dim = [emb_dim]
-        if not isinstance(emb_dim, list):
-            emb_dim = list(emb_dim)
+        if isinstance(embedder.dim, (list, tuple)):
+            emb_dim = tuple(embedder.dim)
+        else:
+            emb_dim = (embedder.dim,)
 
-        hparams_dim = hparams["dim"]
-        if not isinstance(hparams["dim"], (list, tuple)):
-            hparams_dim = [hparams["dim"]]
+        if isinstance(hparams["dim"], (list, tuple)):
+            hparams_dim = tuple(hparams["dim"])
+        else:
+            hparams_dim = (hparams["dim"],)
 
-        self.assertEqual(list(outputs.shape), [64, 16] + emb_dim)
+        self.assertEqual(outputs.size(), (64, 16) + emb_dim)
         self.assertEqual(emb_dim, hparams_dim)
         self.assertEqual(embedder.position_size, 100)
-        seq_length = torch.empty([64]).uniform_(pos_size).type(torch.int32)
+        seq_length = torch.empty(64).uniform_(pos_size).long()
         outputs = embedder(sequence_length=seq_length)
 
     def test_sinusoids_position_embedder(self):
         """Tests :class:`texar.modules.SinusoidsPositionEmbedder`.
         """
         position_size = 64
-        input_size = [100]
+        input_size = (23, 18)
         hparams = {'dim': 513}  # use odd dimension to ensure padding correct
         embedder = SinusoidsPositionEmbedder(position_size, hparams=hparams)
         inputs = torch.randint(position_size - 1, input_size)
         outputs = embedder(inputs)
+        self.assertEqual(outputs.size(), input_size + (hparams['dim'],))
 
-        self.assertEqual(list(outputs.shape), input_size + [hparams['dim']])
+        embedder_no_cache = SinusoidsPositionEmbedder(
+            None, hparams={**hparams, 'cache_embeddings': False})
+        wide_inputs = torch.randint(
+            -position_size, position_size * 2, input_size)
+        wide_outputs = embedder_no_cache(wide_inputs)
+        self.assertEqual(wide_outputs.size(), input_size + (hparams['dim'],))
+        no_cache_outputs = embedder_no_cache(inputs)
+        np.testing.assert_array_equal(outputs, no_cache_outputs)
 
     def test_embedder(self):
         """Tests various embedders.
         """
         test_dims = [
-            1024,
-            [1024],
-            [1024, 10],
+            14,
+            [14],
+            [14, 10],
         ]
         test_hparams = [
             # no dropout
@@ -112,26 +120,25 @@ class EmbedderTest(unittest.TestCase):
     def test_embedder_multi_calls(self):
         """Tests embedders called by multiple times.
         """
-        hparams = {"dim": 1024, "dropout_rate": 0.3,
+        hparams = {"dim": 26, "dropout_rate": 0.3,
                    "dropout_strategy": "item"}
         embedder = WordEmbedder(
             vocab_size=100, hparams=hparams)
-        inputs = torch.ones([64, 16], dtype=torch.int32)
+        inputs = torch.randint(embedder.vocab_size, (64, 16), dtype=torch.long)
         outputs = embedder(inputs)
 
-        emb_dim = embedder.dim
-        if not isinstance(emb_dim, (list, tuple)):
-            emb_dim = [emb_dim]
-        self.assertEqual(list(outputs.shape), [64, 16] + emb_dim)
+        if isinstance(embedder.dim, (list, tuple)):
+            emb_dim = tuple(embedder.dim)
+        else:
+            emb_dim = (embedder.dim,)
+        self.assertEqual(outputs.size(), (64, 16) + emb_dim)
 
         # Call with inputs in a different shape
-        inputs = torch.ones([64, 10, 20], dtype=torch.int32)
+        inputs = torch.randint(
+            embedder.vocab_size, (64, 10, 20), dtype=torch.long)
         outputs = embedder(inputs)
 
-        emb_dim = embedder.dim
-        if not isinstance(emb_dim, (list, tuple)):
-            emb_dim = [emb_dim]
-        self.assertEqual(list(outputs.shape), [64, 10, 20] + emb_dim)
+        self.assertEqual(outputs.size(), (64, 10, 20) + emb_dim)
 
     def test_word_embedder_soft_ids(self):
         """Tests the correctness of using soft ids.
@@ -139,11 +146,11 @@ class EmbedderTest(unittest.TestCase):
         init_value = np.expand_dims(np.arange(5), 1)
         embedder = WordEmbedder(init_value=init_value)
 
-        ids = np.array([3])
-        soft_ids = np.array([[0, 0, 0, 1, 0]])
+        ids = torch.tensor([3])
+        soft_ids = torch.tensor([0, 0, 0, 1, 0], dtype=torch.float)
 
-        outputs = embedder(ids=torch.from_numpy(ids))
-        soft_outputs = embedder(soft_ids=torch.from_numpy(soft_ids))
+        outputs = embedder(ids=ids)
+        soft_outputs = embedder(soft_ids=soft_ids)
         self.assertEqual(outputs, soft_outputs)
 
 


### PR DESCRIPTION
This PR fixes #77.

- Add `"cache_embeddings"` hparam for `SinusoidsPositionEmbedding` to support negative positions & arbitrary-lengthed sequences.
- Add type annotations to all embedder modules.
- Fix unorthodox PyTorch conventions (e.g. use `.size()` instead of `.shape`).