### PR TITLE
Resolve #94 Incorrect dtype under Windows

### DIFF
--- a/texar/data/data/dataset_utils.py
+++ b/texar/data/data/dataset_utils.py
@@ -41,7 +41,7 @@ def padded_batch(examples: Union[List[np.ndarray], List[List[int]]],
     lengths = [len(sent) for sent in examples]
     pad_length = pad_length or max(lengths)
 
-    padded = np.full((len(examples), pad_length), pad_value, dtype=np.long)
+    padded = np.full((len(examples), pad_length), pad_value, dtype=np.int64)
     for b_idx, sent in enumerate(examples):
         length = lengths[b_idx]
         padded[b_idx, :length] = sent[:length]


### PR DESCRIPTION
Change dtype of NumPy array created in `padded_batch` to `np.int64`.

Previously `padded_batch` creates a NumPy array of dtype `np.long`, which is a platform-dependent type, which is equivalent to `int32` under Windows.