### PR TITLE
Add output size to Texar modules

### DIFF
--- a/texar/module_base.py
+++ b/texar/module_base.py
@@ -83,3 +83,9 @@ class ModuleBase(nn.Module, ABC):
         of the module.
         """
         return self._hparams
+
+    @property
+    def output_size(self):
+        r"""The final dimension(s) of :meth:`forward` output tensor(s).
+        """
+        raise NotImplementedError

--- a/texar/modules/classifiers/bert_classifiers.py
+++ b/texar/modules/classifiers/bert_classifiers.py
@@ -260,3 +260,28 @@ class BertClassifier(ClassifierBase):
             preds = torch.flatten(preds)
 
         return logits, preds
+
+    @property
+    def output_size(self) -> int:
+        r"""The final dimension(s) of :meth:`forward` output tensor(s).
+
+        Here output is :attr:`logits`. The final dimension equals to ``1``
+        when output final dimension is only determined by input.
+        """
+        clas_strategy = self._hparams.clas_strategy
+
+        if self._hparams.num_classes < 1:
+            raise NameError("logit_dim cannot be defined "
+                            "if self._hparams.num_classes < 1")
+
+        if clas_strategy in ("cls_time", "all_time"):
+            if self._hparams.num_classes > 1:
+                logit_dim = self._hparams.num_classes
+            elif self._hparams.num_classes == 1:
+                logit_dim = 1
+        elif clas_strategy == "time_wise":
+            if self._hparams.num_classes > 1:
+                logit_dim = self._hparams.num_classes
+            elif self._hparams.num_classes == 1:
+                logit_dim = 1
+        return logit_dim

--- a/texar/modules/classifiers/conv_classifiers.py
+++ b/texar/modules/classifiers/conv_classifiers.py
@@ -241,3 +241,20 @@ class Conv1DClassifier(ClassifierBase):
         r"""A list of uniquified layer names.
         """
         return self._encoder.layer_names
+
+    @property
+    def output_size(self) -> int:
+        r"""The final dimension(s) of :meth:`forward` output tensor(s).
+
+        Here output is :attr:`logits`. The final dimension equals to ``1``
+        when output final dimension is only determined by input.
+        """
+        if self._hparams.num_classes > 1:
+            logit_dim = self._hparams.num_classes
+        elif self._hparams.num_classes == 1:
+            logit_dim = 1
+        else:
+            raise AttributeError("'Conv1DClassifier' object has"
+                                 "no attribute 'output_size'"
+                                 "if 'self._hparams.num_classes' < 1.")
+        return logit_dim

--- a/texar/modules/connectors/connector_base.py
+++ b/texar/modules/connectors/connector_base.py
@@ -68,6 +68,4 @@ class ConnectorBase(ModuleBase, Generic[OutputSize], ABC):
 
     @property
     def output_size(self):
-        r"""The output size.
-        """
         return self._output_size

--- a/texar/modules/decoders/decoder_helpers.py
+++ b/texar/modules/decoders/decoder_helpers.py
@@ -554,7 +554,7 @@ class TopPSampleEmbeddingHelper(SingleEmbeddingHelper):
             ids), or take two arguments (``ids``, ``times``), where ``ids``
             is a vector of argmax ids, and ``times`` is a vector of current
             time steps (i.e., position ids). The latter case can be used
-            when attr:`embedding` is a combination of word embedding and
+            when :attr:`embedding` is a combination of word embedding and
             position embedding.
             The returned tensor will be passed to the decoder input.
         start_tokens: 1D :tensor:`LongTensor` shaped ``[batch_size]``,

--- a/texar/modules/embedders/embedder_base.py
+++ b/texar/modules/embedders/embedder_base.py
@@ -142,3 +142,12 @@ class EmbeddingDropout(ModuleBase):
         mask += input_tensor.new_empty(noise_shape).uniform_(0, 1)
         mask = torch.floor(mask).div_(keep_rate)
         return input_tensor * mask
+
+    @property
+    def output_size(self) -> int:
+        r"""The final dimension(s) of :meth:`forward` output tensor(s).
+
+        Here final dimension is ``1``, because here output tensor size equals
+        to the input tensor size.
+        """
+        return 1

--- a/texar/modules/embedders/embedders.py
+++ b/texar/modules/embedders/embedders.py
@@ -254,3 +254,10 @@ class WordEmbedder(EmbedderBase):
         :class:`~torch.nn.Embedding`.
         """
         return self._vocab_size
+
+    @property
+    def output_size(self) -> int:
+        if isinstance(self._dim, (list, tuple)):
+            return self._dim[-1]
+        else:
+            return self._dim

--- a/texar/modules/embedders/embedders_test.py
+++ b/texar/modules/embedders/embedders_test.py
@@ -41,7 +41,9 @@ class EmbedderTest(unittest.TestCase):
             hparams_dim = (hparams["dim"],)
 
         self.assertEqual(outputs.size(), (64, 16) + emb_dim)
+        self.assertEqual(outputs.size(-1), embedder.output_size)
         self.assertEqual(outputs_soft.size(), (64, 16) + emb_dim)
+        self.assertEqual(outputs_soft.size(-1), embedder.output_size)
         self.assertEqual(emb_dim, hparams_dim)
         self.assertEqual(embedder.vocab_size, 100)
         self.assertEqual(outputs.size(), (64, 16) + emb_dim)
@@ -67,6 +69,7 @@ class EmbedderTest(unittest.TestCase):
             hparams_dim = (hparams["dim"],)
 
         self.assertEqual(outputs.size(), (64, 16) + emb_dim)
+        self.assertEqual(outputs.size(-1), embedder.output_size)
         self.assertEqual(emb_dim, hparams_dim)
         self.assertEqual(embedder.position_size, 100)
         seq_length = torch.empty(64).uniform_(pos_size).long()
@@ -82,6 +85,7 @@ class EmbedderTest(unittest.TestCase):
         inputs = torch.randint(position_size - 1, input_size)
         outputs = embedder(inputs)
         self.assertEqual(outputs.size(), input_size + (hparams['dim'],))
+        self.assertEqual(outputs.size(-1), embedder.output_size)
 
         embedder_no_cache = SinusoidsPositionEmbedder(
             None, hparams={**hparams, 'cache_embeddings': False})

--- a/texar/modules/embedders/position_embedders.py
+++ b/texar/modules/embedders/position_embedders.py
@@ -193,6 +193,13 @@ class PositionEmbedder(EmbedderBase):
         """
         return self._position_size
 
+    @property
+    def output_size(self) -> int:
+        if isinstance(self._dim, (list, tuple)):
+            return self._dim[-1]
+        else:
+            return self._dim
+
 
 class SinusoidsPositionEmbedder(EmbedderBase):
     r"""Sinusoid position embedder that maps position indexes into embeddings
@@ -342,3 +349,11 @@ class SinusoidsPositionEmbedder(EmbedderBase):
             outputs = mask_sequences(outputs, sequence_length)
 
         return outputs
+
+    @property
+    def output_size(self) -> int:
+        if isinstance(self._dim, (list, tuple)):
+            dim = self._dim[-1]
+        else:
+            dim = self._dim
+        return dim

--- a/texar/modules/encoders/conv_encoders_test.py
+++ b/texar/modules/encoders/conv_encoders_test.py
@@ -11,15 +11,15 @@ from texar.modules.encoders.conv_encoders import Conv1DEncoder
 
 
 class Conv1DEncoderTest(unittest.TestCase):
-    """Tests :class:`~texar.modules.Conv1DEncoder` class.
+    r"""Tests :class:`~texar.modules.Conv1DEncoder` class.
     """
 
     def test_encode(self):
-        """Tests encode.
+        r"""Tests encode.
         """
         inputs_1 = torch.ones([128, 32, 300])
-        encoder_1 = Conv1DEncoder(in_channels=inputs_1.shape[1],
-                                  in_features=inputs_1.shape[2])
+        encoder_1 = Conv1DEncoder(in_channels=inputs_1.size(1),
+                                  in_features=inputs_1.size(2))
         self.assertEqual(len(encoder_1.layers), 4)
         self.assertTrue(isinstance(encoder_1.layer_by_name("MergeLayer"),
                                    tx.core.MergeLayer))
@@ -27,7 +27,8 @@ class Conv1DEncoderTest(unittest.TestCase):
             self.assertTrue(isinstance(layer, nn.Sequential))
 
         outputs_1 = encoder_1(inputs_1)
-        self.assertEqual(outputs_1.shape, torch.Size([128, 256]))
+        self.assertEqual(outputs_1.size(), torch.Size([128, 256]))
+        self.assertEqual(outputs_1.size(-1), encoder_1.output_size)
 
         inputs_2 = torch.ones([128, 64, 300])
         hparams = {
@@ -49,8 +50,8 @@ class Conv1DEncoderTest(unittest.TestCase):
             "dropout_conv": [0, 1, 2],
             "dropout_dense": 2
         }
-        network_2 = Conv1DEncoder(in_channels=inputs_2.shape[1],
-                                  in_features=inputs_2.shape[2],
+        network_2 = Conv1DEncoder(in_channels=inputs_2.size(1),
+                                  in_features=inputs_2.size(2),
                                   hparams=hparams)
         # dropout-merge-dropout-conv-avgpool-dropout-flatten-
         # (Sequential(Linear,ReLU))-(Sequential(Linear,ReLU))-dropout-linear
@@ -61,7 +62,8 @@ class Conv1DEncoderTest(unittest.TestCase):
             self.assertTrue(isinstance(layer, nn.Sequential))
 
         outputs_2 = network_2(inputs_2)
-        self.assertEqual(outputs_2.shape, torch.Size([128, 10]))
+        self.assertEqual(outputs_2.size(), torch.Size([128, 10]))
+        self.assertEqual(outputs_2.size(-1), network_2.output_size)
 
 
 if __name__ == "__main__":

--- a/texar/modules/encoders/multihead_attention.py
+++ b/texar/modules/encoders/multihead_attention.py
@@ -255,6 +255,4 @@ class MultiheadAttentionEncoder(EncoderBase):
 
     @property
     def output_size(self):
-        r"""Provides output dimension as property.
-        """
         return self._hparams.output_dim

--- a/texar/modules/encoders/rnn_encoders.py
+++ b/texar/modules/encoders/rnn_encoders.py
@@ -460,6 +460,18 @@ class UnidirectionalRNNEncoder(RNNEncoderBase[State]):
         """
         return self._output_layer
 
+    @property
+    def output_size(self) -> int:
+        # TODO: We will change the implementation to
+        # something that does not require a forward pass.
+
+        dim = self._cell.hidden_size
+        dummy_tensor = torch.Tensor(dim)
+        if self._output_layer is not None:
+            return self._output_layer(dummy_tensor).size(-1)
+        else:
+            return dim
+
 
 class BidirectionalRNNEncoder(RNNEncoderBase):
     r"""Bidirectional forward-backward RNN encoder.
@@ -788,3 +800,26 @@ class BidirectionalRNNEncoder(RNNEncoderBase):
         r"""The output layer of the backward RNN.
         """
         return self._output_layer_bw
+
+    @property
+    def output_size(self) -> Tuple[int, int]:
+        r"""The final dimension(s) of :meth:`forward` output tensor(s).
+
+        Here final dimension is a tuple consisting of forward
+        RNN final dimension and backward RNN final dimension.
+        """
+        # TODO: We will change the implementation to
+        # something that does not require a forward pass.
+        dim_bw = self._cell_bw.hidden_size
+        dummy_tensor_bw = torch.Tensor(dim_bw)
+        dim_fw = self._cell_fw.hidden_size
+        dummy_tensor_fw = torch.Tensor(dim_fw)
+        if self._output_layer_bw is not None:
+            output_bw = self._output_layer_bw(dummy_tensor_bw).size()[-1]
+        else:
+            output_bw = dim_bw
+        if self._output_layer_fw is not None:
+            output_fw = self._output_layer_fw(dummy_tensor_fw).size()[-1]
+        else:
+            output_fw = dim_fw
+        return (output_fw, output_bw)

--- a/texar/modules/encoders/rnn_encoders_test.py
+++ b/texar/modules/encoders/rnn_encoders_test.py
@@ -13,7 +13,7 @@ from texar.modules.encoders.rnn_encoders import (
 
 
 class UnidirectionalRNNEncoderTest(unittest.TestCase):
-    """Tests unidirectional rnn encoder.
+    r"""Tests unidirectional rnn encoder.
     """
 
     def setUp(self):
@@ -22,15 +22,16 @@ class UnidirectionalRNNEncoderTest(unittest.TestCase):
         self._input_size = 10
 
     def test_trainable_variables(self):
-        """Tests the functionality of automatically collecting trainable
+        r"""Tests the functionality of automatically collecting trainable
         variables.
         """
         inputs = torch.rand(self._batch_size, self._max_time, self._input_size)
 
         # case 1
         encoder = UnidirectionalRNNEncoder(input_size=self._input_size)
-        _, _ = encoder(inputs)
+        output, _ = encoder(inputs)
         self.assertEqual(len(encoder.trainable_variables), 4)
+        self.assertEqual(output.size()[-1], encoder.output_size)
 
         # case 2
         hparams = {
@@ -42,8 +43,9 @@ class UnidirectionalRNNEncoderTest(unittest.TestCase):
         }
         encoder = UnidirectionalRNNEncoder(input_size=self._input_size,
                                            hparams=hparams)
-        _, _ = encoder(inputs)
+        output, _ = encoder(inputs)
         self.assertEqual(len(encoder.trainable_variables), 4)
+        self.assertEqual(output.size()[-1], encoder.output_size)
 
         # case 3
         hparams = {"output_layer": {
@@ -57,11 +59,12 @@ class UnidirectionalRNNEncoderTest(unittest.TestCase):
         encoder = UnidirectionalRNNEncoder(input_size=self._input_size,
                                            hparams=hparams)
 
-        _, _ = encoder(inputs)
+        output, _ = encoder(inputs)
         self.assertEqual(len(encoder.trainable_variables), 8)
+        self.assertEqual(output.size()[-1], encoder.output_size)
 
     def test_encode(self):
-        """Tests encoding.
+        r"""Tests encoding.
         """
         inputs = torch.rand(self._batch_size, self._max_time, self._input_size)
 
@@ -104,7 +107,7 @@ class UnidirectionalRNNEncoderTest(unittest.TestCase):
 
 
 class BidirectionalRNNEncoderTest(unittest.TestCase):
-    """Tests bidirectional rnn encoder.
+    r"""Tests bidirectional rnn encoder.
     """
 
     def setUp(self):
@@ -113,15 +116,17 @@ class BidirectionalRNNEncoderTest(unittest.TestCase):
         self._input_size = 10
 
     def test_trainable_variables(self):
-        """Tests the functionality of automatically collecting trainable
+        r"""Tests the functionality of automatically collecting trainable
         variables.
         """
         inputs = torch.rand(self._batch_size, self._max_time, self._input_size)
 
         # case 1
         encoder = BidirectionalRNNEncoder(input_size=self._input_size)
-        _, _ = encoder(inputs)
+        outputs, _ = encoder(inputs)
         self.assertEqual(len(encoder.trainable_variables), 8)
+        self.assertEqual(
+            (outputs[0].size(-1), outputs[1].size(-1)), (encoder.output_size))
 
         # case 2
         hparams = {
@@ -133,8 +138,10 @@ class BidirectionalRNNEncoderTest(unittest.TestCase):
         }
         encoder = BidirectionalRNNEncoder(input_size=self._input_size,
                                           hparams=hparams)
-        _, _ = encoder(inputs)
+        outputs, _ = encoder(inputs)
         self.assertEqual(len(encoder.trainable_variables), 8)
+        self.assertEqual(
+            (outputs[0].size(-1), outputs[1].size(-1)), (encoder.output_size))
 
         # case 3
         hparams = {
@@ -154,11 +161,13 @@ class BidirectionalRNNEncoderTest(unittest.TestCase):
         }
         encoder = BidirectionalRNNEncoder(input_size=self._input_size,
                                           hparams=hparams)
-        _, _ = encoder(inputs)
+        outputs, _ = encoder(inputs)
         self.assertEqual(len(encoder.trainable_variables), 8 + 3 + 4)
+        self.assertEqual(
+            (outputs[0].size(-1), outputs[1].size(-1)), (encoder.output_size))
 
     def test_encode(self):
-        """Tests encoding.
+        r"""Tests encoding.
         """
         inputs = torch.rand(self._batch_size, self._max_time, self._input_size)
 

--- a/texar/modules/encoders/transformer_encoder.py
+++ b/texar/modules/encoders/transformer_encoder.py
@@ -381,3 +381,7 @@ class TransformerEncoder(EncoderBase):
         if not self._hparams.use_bert_config:
             x = self.final_layer_normalizer(x)
         return x
+
+    @property
+    def output_size(self) -> int:
+        return self._hparams.dim

--- a/texar/modules/encoders/transformer_encoder_test.py
+++ b/texar/modules/encoders/transformer_encoder_test.py
@@ -28,13 +28,14 @@ class TransformerEncoderTest(unittest.TestCase):
 
         encoder = TransformerEncoder()
 
-        _ = encoder(inputs=inputs, sequence_length=sequence_length)
+        outputs = encoder(inputs=inputs, sequence_length=sequence_length)
 
         # 6 blocks
         # -self multihead_attention: 4 dense without bias + 2 layer norm vars
         # -poswise_network: Dense with bias, Dense with bias + 2 layer norm vars
         # 2 output layer norm vars
         self.assertEqual(len(encoder.trainable_variables), 74)
+        self.assertEqual(outputs.size(-1), encoder.output_size)
 
         hparams = {"use_bert_config": True}
         encoder = TransformerEncoder(hparams=hparams)
@@ -44,8 +45,9 @@ class TransformerEncoderTest(unittest.TestCase):
         # -poswise_network: Dense with bias, Dense with bias + 2 layer norm vars
         # -output: 2 layer norm vars
         # 2 input layer norm vars
-        _ = encoder(inputs=inputs, sequence_length=sequence_length)
+        outputs = encoder(inputs=inputs, sequence_length=sequence_length)
         self.assertEqual(len(encoder.trainable_variables), 74)
+        self.assertEqual(outputs.size(-1), encoder.output_size)
 
     def test_encode(self):
         r"""Tests encoding.

--- a/texar/modules/networks/conv_networks.py
+++ b/texar/modules/networks/conv_networks.py
@@ -531,3 +531,14 @@ class Conv1DNetwork(FeedForwardNetworkBase):
         with torch.no_grad():
             output = super().forward(input)
         return output.view(output.size()[0], -1).size()
+
+    @property
+    def output_size(self) -> int:
+        if self.hparams.num_dense_layers <= 0:
+            return self._hparams.out_channels * len(self._hparams.kernel_size)
+        else:
+            out_features = self._hparams.out_features
+            if isinstance(out_features, (list, tuple)):
+                return out_features[-1]
+            else:
+                return out_features

--- a/texar/modules/networks/conv_networks_test.py
+++ b/texar/modules/networks/conv_networks_test.py
@@ -30,6 +30,7 @@ class Conv1DNetworkTest(unittest.TestCase):
 
         outputs_1 = network_1(inputs_1)
         self.assertEqual(outputs_1.shape, torch.Size([128, 256]))
+        self.assertEqual(outputs_1.size(-1), network_1.output_size)
 
         inputs_2 = torch.ones([128, 64, 300])
         hparams = {
@@ -66,7 +67,7 @@ class Conv1DNetworkTest(unittest.TestCase):
 
         outputs_2 = network_2(inputs_2)
         self.assertEqual(outputs_2.shape, torch.Size([128, 10]))
-
+        self.assertEqual(outputs_2.size(-1), network_2.output_size)
         # test whether concatenation happens along channel dim when feature dim
         # has been reduced
         hparams = {
@@ -98,6 +99,7 @@ class Conv1DNetworkTest(unittest.TestCase):
         out_channels = hparams["out_channels"]
         self.assertEqual(outputs_3.shape,
                          torch.Size([128, num_of_kernels * out_channels]))
+        self.assertEqual(outputs_3.size(-1), network_3.output_size)
 
 
 if __name__ == "__main__":

--- a/texar/modules/networks/networks.py
+++ b/texar/modules/networks/networks.py
@@ -16,6 +16,7 @@ Various neural networks and related utilities.
 """
 
 from texar.modules.networks.network_base import FeedForwardNetworkBase
+from texar.utils.utils import get_output_size
 
 __all__ = [
     "FeedForwardNetwork",
@@ -82,3 +83,17 @@ class FeedForwardNetwork(FeedForwardNetworkBase):
             "layers": [],
             "name": "NN"
         }
+
+    @property
+    def output_size(self) -> int:
+        r"""The final dimension(s) of :meth:`forward` output tensor(s).
+
+        Here final dimension equals to ``1`` if unable to get output size
+        from network layers.
+        """
+
+        for layer in reversed(self._layers):
+            size = get_output_size(layer)
+            if size is not None:
+                return size
+        return 1

--- a/texar/modules/networks/networks_test.py
+++ b/texar/modules/networks/networks_test.py
@@ -39,9 +39,10 @@ class FeedForwardNetworkTest(unittest.TestCase):
         nn = FeedForwardNetwork(hparams=hparams)
 
         self.assertEqual(len(nn.layers), len(hparams["layers"]))
-        _ = nn(torch.ones(64, 16, 32))
+        outputs = nn(torch.ones(64, 16, 32))
         self.assertEqual(len(nn.trainable_variables),
                          len(hparams["layers"]) * 2)
+        self.assertEqual(outputs.size(-1), nn.output_size)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add property `output_size` to `Modulebase` and its sub-modules;
Modify sub-modules in `modules` to adjust the computation.