### PR TITLE
Add vae_text example

### DIFF
--- a/examples/vae_text/README.md
+++ b/examples/vae_text/README.md
@@ -1,0 +1,57 @@
+# Variational Autoencoder (VAE) for Text Generation
+
+This example builds a VAE for text generation, with an LSTM as encoder and an LSTM or [Transformer](https://arxiv.org/pdf/1706.03762.pdf) as decoder. Training is performed on the official PTB data and Yahoo data, respectively. 
+
+The VAE with LSTM decoder is first decribed in [(Bowman et al., 2015) Generating Sentences from a Continuous Space](https://arxiv.org/pdf/1511.06349.pdf)
+
+The Yahoo dataset is from [(Yang et al., 2017) Improved Variational Autoencoders for Text Modeling using Dilated Convolutions](https://arxiv.org/pdf/1702.08139.pdf), which is created by sampling 100k documents from the original Yahoo Answer data. The average document length is 78 and the vocab size is 200k. 
+
+## Data
+The datasets can be downloaded by running:
+```shell
+python prepare_data.py --data ptb
+python prepare_data.py --data yahoo
+```
+
+## Training
+Train with the following command:
+
+```shell
+python vae_train.py --config config_trans_ptb
+```
+
+Here:
+
+* `--config` specifies the config file to use, including model hyperparameters and data paths. We provide 4 config files:
+  - [config_lstm_ptb.py](./config_lstm_ptb.py): LSTM decoder, on the PTB data
+  - [config_lstm_yahoo.py](./config_lstm_yahoo.py): LSTM decoder, on the Yahoo data
+  - [config_trans_ptb.py](./config_trans_ptb.py): Transformer decoder, on the PTB data
+  - [config_trans_yahoo.py](./config_trans_yahoo.py): Transformer decoder, on the Yahoo data
+
+## Generation
+Generating sentences with pre-trained model can be performed with the following command:
+```shell
+python vae_train.py --config config_file --mode predict --model /path/to/model.ckpt --out /path/to/output
+```
+
+Here `--model` specifies the saved model checkpoint, which is saved in `./models/dataset_name/` at training time. For example, the model path is `./models/ptb/ptb_lstmDecoder.ckpt` when generating with a LSTM decoder trained on PTB dataset. Generated sentences will be written to standard output if `--out` is not specifcied.
+
+## Results
+
+### Language Modeling
+
+|Dataset    |Metrics   | VAE-LSTM |VAE-Transformer |
+|---------------|-------------|----------------|------------------------|
+|Yahoo | Test PPL<br>Test NLL | 68.11<br>337.13 |59.95<br>326.93|
+|PTB | Test PPL<br>Test NLL | 104.61<br>101.92 | 103.68<br>101.72 |
+
+### Generated Examples
+We show the generated examples with transformer as decoder trained  on PTB training data.
+
+|Examples|
+|:---------|
+|i 'm always looking at a level of \$ N to \$ N billion \<EOS\> |
+|after four years ago president bush has federal regulators decided to file financing for the waiver\<EOS\> |
+|the savings & loan association said total asset revenue was about \$ N billion compared with \$ N billion \<EOS\> |
+|the trend would seem to be effective \<EOS\> |
+|chicago city 's <unk> computer bank of britain posted a N N jump in third-quarter net income \<EOS\>|

--- a/examples/vae_text/README.md
+++ b/examples/vae_text/README.md
@@ -43,15 +43,15 @@ Here `--model` specifies the saved model checkpoint, which is saved in `./models
 |Dataset    |Metrics   | VAE-LSTM |VAE-Transformer |
 |---------------|-------------|----------------|------------------------|
 |Yahoo | Test PPL<br>Test NLL | 68.11<br>337.13 |59.95<br>326.93|
-|PTB | Test PPL<br>Test NLL | 104.61<br>101.92 | 103.68<br>101.72 |
+|PTB | Test PPL<br>Test NLL | 107.87<br>102.59 | 102.28<br>101.43 |
 
 ### Generated Examples
 We show the generated examples with transformer as decoder trained  on PTB training data.
 
 |Examples|
 |:---------|
-|i 'm always looking at a level of \$ N to \$ N billion \<EOS\> |
-|after four years ago president bush has federal regulators decided to file financing for the waiver\<EOS\> |
-|the savings & loan association said total asset revenue was about \$ N billion compared with \$ N billion \<EOS\> |
-|the trend would seem to be effective \<EOS\> |
-|chicago city 's <unk> computer bank of britain posted a N N jump in third-quarter net income \<EOS\>|
+|we 've been more quickly accomplished in our old and more than in the past is in these industries said steven <unk> publisher of <unk> <unk> inc. of the workstation market set crazy \<EOS\>|
+|chung <unk> 's proposal that saved the page in september and the ad pages \$ N from yale city with more than a small fee that tenants had been made by support in the past N years ago \<EOS\>|
+|the university of state commerce was <unk> from cooperation last year when it controls for cleaning up a bipartisan aid to moscow new arms-control <unk> <unk> \<EOS\>|
+|the <unk> maker general electric co. 's electronics and the <unk> for <unk> radar tools that included for space at krasnoyarsk \<EOS\>|
+|the company said its travel subsidiary has been operating for \$ N million \<EOS\>|

--- a/examples/vae_text/README.md
+++ b/examples/vae_text/README.md
@@ -42,7 +42,7 @@ Here `--model` specifies the saved model checkpoint, which is saved in `./models
 
 |Dataset    |Metrics   | VAE-LSTM |VAE-Transformer |
 |---------------|-------------|----------------|------------------------|
-|Yahoo | Test PPL<br>Test NLL | 68.11<br>337.13 |59.95<br>326.93|
+|Yahoo | Test PPL<br>Test NLL | 75.21<br>336.41 |67.81<br>328.34|
 |PTB | Test PPL<br>Test NLL | 107.87<br>102.59 | 102.28<br>101.43 |
 
 ### Generated Examples
@@ -50,8 +50,8 @@ We show the generated examples with transformer as decoder trained  on PTB train
 
 |Examples|
 |:---------|
-|we 've been more quickly accomplished in our old and more than in the past is in these industries said steven <unk> publisher of <unk> <unk> inc. of the workstation market set crazy \<EOS\>|
+|regarded as the result of the market <unk> has three currencies as unusual as <unk> companies \<EOS\>|
 |chung <unk> 's proposal that saved the page in september and the ad pages \$ N from yale city with more than a small fee that tenants had been made by support in the past N years ago \<EOS\>|
 |the university of state commerce was <unk> from cooperation last year when it controls for cleaning up a bipartisan aid to moscow new arms-control <unk> <unk> \<EOS\>|
-|the <unk> maker general electric co. 's electronics and the <unk> for <unk> radar tools that included for space at krasnoyarsk \<EOS\>|
+|his return was the unusual of its operations in reacting to the day \<EOS\>|
 |the company said its travel subsidiary has been operating for \$ N million \<EOS\>|

--- a/examples/vae_text/README.md
+++ b/examples/vae_text/README.md
@@ -42,8 +42,8 @@ Here `--model` specifies the saved model checkpoint, which is saved in `./models
 
 |Dataset    |Metrics   | VAE-LSTM |VAE-Transformer |
 |---------------|-------------|----------------|------------------------|
-|Yahoo | Test PPL<br>Test NLL | 69.42<br>338.65 |67.81<br>328.34|
-|PTB | Test PPL<br>Test NLL | 107.87<br>102.59 | 102.28<br>101.43 |
+|Yahoo | Test PPL<br>Test NLL | 69.85<br>339.15 |60.78<br>328.03|
+|PTB | Test PPL<br>Test NLL | 107.64<br>102.54 | 103.14<br>101.61 |
 
 ### Generated Examples
 We show the generated examples with transformer as decoder trained  on PTB training data.

--- a/examples/vae_text/README.md
+++ b/examples/vae_text/README.md
@@ -50,8 +50,8 @@ We show the generated examples with transformer as decoder trained  on PTB train
 
 |Examples|
 |:---------|
-|regarded as the result of the market <unk> has three currencies as unusual as <unk> companies \<EOS\>|
-|chung <unk> 's proposal that saved the page in september and the ad pages \$ N from yale city with more than a small fee that tenants had been made by support in the past N years ago \<EOS\>|
-|the university of state commerce was <unk> from cooperation last year when it controls for cleaning up a bipartisan aid to moscow new arms-control <unk> <unk> \<EOS\>|
-|his return was the unusual of its operations in reacting to the day \<EOS\>|
-|the company said its travel subsidiary has been operating for \$ N million \<EOS\>|
+|mostly in its annual <unk> spending N in september to $ N billion from $ N billion a year earlier \<EOS\>|
+|note it 's a N rating of N N owned by shareholders from the banking and the expectation of interest payment since trading of a sale of a stock was a effect \<EOS\>|
+|but the profit margin eye on its rise disrupted that cms had slashed its quarterly profit in the quarter \<EOS\>|
+|that weeks ago the new business was to follow the dollar \<EOS\>|
+|the issue was quoted at N marks and for november delivery of N cent \<EOS\>|

--- a/examples/vae_text/README.md
+++ b/examples/vae_text/README.md
@@ -42,7 +42,7 @@ Here `--model` specifies the saved model checkpoint, which is saved in `./models
 
 |Dataset    |Metrics   | VAE-LSTM |VAE-Transformer |
 |---------------|-------------|----------------|------------------------|
-|Yahoo | Test PPL<br>Test NLL | 75.21<br>336.41 |67.81<br>328.34|
+|Yahoo | Test PPL<br>Test NLL | 69.42<br>338.65 |67.81<br>328.34|
 |PTB | Test PPL<br>Test NLL | 107.87<br>102.59 | 102.28<br>101.43 |
 
 ### Generated Examples

--- a/examples/vae_text/config_lstm_ptb.py
+++ b/examples/vae_text/config_lstm_ptb.py
@@ -1,0 +1,138 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VAE config.
+"""
+
+# pylint: disable=invalid-name, too-few-public-methods, missing-docstring
+
+dataset = "ptb"
+num_epochs = 100
+hidden_size = 256
+dec_dropout_in = 0.5
+dec_dropout_out = 0.5
+enc_dropout_in = 0.
+enc_dropout_out = 0.
+word_keep_prob = 0.5
+batch_size = 32
+embed_dim = 256
+
+latent_dims = 32
+
+lr_decay_hparams = {
+    "init_lr": 0.001,
+    "threshold": 2,
+    "decay_factor": 0.5,
+    "max_decay": 5
+}
+
+
+decoder_type = 'lstm'
+
+enc_cell_hparams = {
+    "type": "LSTMCell",
+    "kwargs": {
+        "num_units": hidden_size,
+        "forget_bias": 0.
+    },
+    "dropout": {"output_keep_prob": 1. - enc_dropout_out},
+    "num_layers": 1
+}
+
+dec_cell_hparams = {
+    "type": "LSTMCell",
+    "kwargs": {
+        "num_units": hidden_size,
+        "forget_bias": 0.,
+    },
+    "dropout": {"output_keep_prob": 1. - dec_dropout_out},
+    "num_layers": 1,
+}
+
+enc_emb_hparams = {
+    'name': 'lookup_table',
+    "dim": embed_dim,
+    "dropout_rate": enc_dropout_in,
+    'initializer': {
+        'type': 'normal_',
+        'kwargs': {
+            'mean': 0.0,
+            'std': embed_dim**-0.5,
+        },
+    }
+}
+
+dec_emb_hparams = {
+    'name': 'lookup_table',
+    "dim": embed_dim,
+    "dropout_rate": dec_dropout_in,
+    'initializer': {
+        'type': 'normal_',
+        'kwargs': {
+            'mean': 0.0,
+            'std': embed_dim**-0.5,
+        },
+    }
+}
+
+# KL annealing
+kl_anneal_hparams = {
+    "warm_up": 10,
+    "start": 0.1
+}
+
+train_data_hparams = {
+    "num_epochs": 1,
+    "batch_size": batch_size,
+    "seed": 123,
+    "dataset": {
+        "files": './simple-examples/data/ptb.train.txt',
+        "vocab_file": './simple-examples/data/vocab.txt'
+    }
+}
+
+val_data_hparams = {
+    "num_epochs": 1,
+    "batch_size": batch_size,
+    "seed": 123,
+    "dataset": {
+        "files": './simple-examples/data/ptb.valid.txt',
+        "vocab_file": './simple-examples/data/vocab.txt'
+    }
+}
+
+test_data_hparams = {
+    "num_epochs": 1,
+    "batch_size": batch_size,
+    "dataset": {
+        "files": './simple-examples/data/ptb.test.txt',
+        "vocab_file": './simple-examples/data/vocab.txt'
+    }
+}
+
+opt_hparams = {
+    'optimizer': {
+        'type': 'Adam',
+        'kwargs': {
+            'lr': 0.001
+        }
+    },
+    'gradient_clip': {
+        "type": "clip_grad_norm_",
+        "kwargs": {
+            "max_norm": 5,
+            "norm_type": 2
+        }
+    }
+}

--- a/examples/vae_text/config_lstm_ptb.py
+++ b/examples/vae_text/config_lstm_ptb.py
@@ -15,8 +15,6 @@
 """VAE config.
 """
 
-# pylint: disable=invalid-name, too-few-public-methods, missing-docstring
-
 dataset = "ptb"
 num_epochs = 100
 hidden_size = 256

--- a/examples/vae_text/config_lstm_ptb.py
+++ b/examples/vae_text/config_lstm_ptb.py
@@ -42,7 +42,7 @@ enc_cell_hparams = {
     "type": "LSTMCell",
     "kwargs": {
         "num_units": hidden_size,
-        "forget_bias": 0.
+        "bias": 0.
     },
     "dropout": {"output_keep_prob": 1. - enc_dropout_out},
     "num_layers": 1
@@ -52,7 +52,7 @@ dec_cell_hparams = {
     "type": "LSTMCell",
     "kwargs": {
         "num_units": hidden_size,
-        "forget_bias": 0.,
+        "bias": 0.,
     },
     "dropout": {"output_keep_prob": 1. - dec_dropout_out},
     "num_layers": 1,

--- a/examples/vae_text/config_lstm_yahoo.py
+++ b/examples/vae_text/config_lstm_yahoo.py
@@ -47,7 +47,7 @@ enc_cell_hparams = {
     "type": "LSTMCell",
     "kwargs": {
         "num_units": hidden_size,
-        "forget_bias": 0.
+        "bias": 0.
     },
     "dropout": {"output_keep_prob": 1. - enc_dropout_out},
     "num_layers": 1
@@ -57,7 +57,7 @@ dec_cell_hparams = {
     "type": "LSTMCell",
     "kwargs": {
         "num_units": hidden_size,
-        "forget_bias": 0.
+        "bias": 0.
     },
     "dropout": {"output_keep_prob": 1. - dec_dropout_out},
     "num_layers": 1

--- a/examples/vae_text/config_lstm_yahoo.py
+++ b/examples/vae_text/config_lstm_yahoo.py
@@ -15,8 +15,6 @@
 """VAE config.
 """
 
-# pylint: disable=invalid-name, too-few-public-methods, missing-docstring
-
 dataset = "yahoo"
 num_epochs = 100
 hidden_size = 550

--- a/examples/vae_text/config_lstm_yahoo.py
+++ b/examples/vae_text/config_lstm_yahoo.py
@@ -1,0 +1,145 @@
+# Copyright 2018 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VAE config.
+"""
+
+# pylint: disable=invalid-name, too-few-public-methods, missing-docstring
+
+dataset = "yahoo"
+num_epochs = 100
+hidden_size = 550
+dec_dropout_in = 0.5
+dec_dropout_out = 0.5
+enc_dropout_in = 0.
+enc_dropout_out = 0.
+batch_size = 32
+embed_dim = 512
+
+latent_dims = 32
+
+lr_decay_hparams = {
+    "init_lr": 0.001,
+    "threshold": 2,
+    "decay_factor": 0.5,
+    "max_decay": 5
+}
+
+
+relu_dropout = 0.2
+embedding_dropout = 0.2
+attention_dropout = 0.2
+residual_dropout = 0.2
+num_blocks = 3
+
+decoder_type = 'lstm'
+
+enc_cell_hparams = {
+    "type": "LSTMCell",
+    "kwargs": {
+        "num_units": hidden_size,
+        "forget_bias": 0.
+    },
+    "dropout": {"output_keep_prob": 1. - enc_dropout_out},
+    "num_layers": 1
+}
+
+dec_cell_hparams = {
+    "type": "LSTMCell",
+    "kwargs": {
+        "num_units": hidden_size,
+        "forget_bias": 0.
+    },
+    "dropout": {"output_keep_prob": 1. - dec_dropout_out},
+    "num_layers": 1
+}
+
+enc_emb_hparams = {
+    'name': 'lookup_table',
+    "dim": embed_dim,
+    "dropout_rate": enc_dropout_in,
+    'initializer': {
+        'type': 'normal_',
+        'kwargs': {
+            'mean': 0.0,
+            'std': embed_dim**-0.5,
+        },
+    }
+}
+
+dec_emb_hparams = {
+    'name': 'lookup_table',
+    "dim": embed_dim,
+    "dropout_rate": dec_dropout_in,
+    'initializer': {
+        'type': 'normal_',
+        'kwargs': {
+            'mean': 0.0,
+            'std': embed_dim**-0.5,
+        },
+    }
+}
+
+
+# KL annealing
+# kl_weight = 1.0 / (1 + np.exp(-k*(step-x0)))
+kl_anneal_hparams = {
+    "warm_up": 10,
+    "start": 0.1
+}
+
+train_data_hparams = {
+    "num_epochs": 1,
+    "batch_size": batch_size,
+    "seed": 123,
+    "dataset": {
+        "files": './data/yahoo/yahoo.train.txt',
+        "vocab_file": './data/yahoo/vocab.txt'
+    }
+}
+
+val_data_hparams = {
+    "num_epochs": 1,
+    "batch_size": batch_size,
+    "seed": 123,
+    "dataset": {
+        "files": './data/yahoo/yahoo.valid.txt',
+        "vocab_file": './data/yahoo/vocab.txt'
+    }
+}
+
+test_data_hparams = {
+    "num_epochs": 1,
+    "batch_size": batch_size,
+    "dataset": {
+        "files": './data/yahoo/yahoo.test.txt',
+        "vocab_file": './data/yahoo/vocab.txt'
+    }
+}
+
+opt_hparams = {
+    "optimizer": {
+        "type": "Adam",
+        "kwargs": {
+            "lr": 0.001
+        }
+    },
+    'gradient_clip': {
+        "type": "clip_grad_norm_",
+        "kwargs": {
+            "max_norm": 5,
+            "norm_type": 2
+        }
+    }
+}

--- a/examples/vae_text/config_trans_ptb.py
+++ b/examples/vae_text/config_trans_ptb.py
@@ -14,8 +14,6 @@
 """Config file of VAE with Trasnformer decoder, on PTB data.
 """
 
-# pylint: disable=invalid-name, too-few-public-methods, missing-docstring
-
 dataset = 'ptb'
 num_epochs = 100
 hidden_size = 256

--- a/examples/vae_text/config_trans_ptb.py
+++ b/examples/vae_text/config_trans_ptb.py
@@ -45,7 +45,7 @@ enc_cell_hparams = {
     'type': 'LSTMCell',
     'kwargs': {
         'num_units': hidden_size,
-        'forget_bias': 0.
+        'bias': 0.
     },
     'dropout': {'output_keep_prob': 1. - enc_dropout_out},
     'num_layers': 1

--- a/examples/vae_text/config_trans_ptb.py
+++ b/examples/vae_text/config_trans_ptb.py
@@ -1,0 +1,189 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Config file of VAE with Trasnformer decoder, on PTB data.
+"""
+
+# pylint: disable=invalid-name, too-few-public-methods, missing-docstring
+
+dataset = 'ptb'
+num_epochs = 100
+hidden_size = 256
+dec_dropout_in = 0.
+enc_dropout_in = 0.
+enc_dropout_out = 0.
+batch_size = 32
+embed_dim = 256
+
+latent_dims = 32
+
+lr_decay_hparams = {
+    'init_lr': 0.001,
+    'threshold': 2,
+    'decay_factor': 0.5,
+    'max_decay': 5
+}
+
+
+relu_dropout = 0.2
+embedding_dropout = 0.2
+attention_dropout = 0.2
+residual_dropout = 0.2
+num_blocks = 3
+
+decoder_type = 'transformer'
+
+enc_cell_hparams = {
+    'type': 'LSTMCell',
+    'kwargs': {
+        'num_units': hidden_size,
+        'forget_bias': 0.
+    },
+    'dropout': {'output_keep_prob': 1. - enc_dropout_out},
+    'num_layers': 1
+}
+
+enc_emb_hparams = {
+    'name': 'lookup_table',
+    'dim': embed_dim,
+    'dropout_rate': enc_dropout_in,
+    'initializer': {
+        'type': 'normal_',
+        'kwargs': {
+            'mean': 0.0,
+            'std': embed_dim**-0.5,
+        },
+    }
+}
+
+dec_emb_hparams = {
+    'name': 'lookup_table',
+    'dim': embed_dim,
+    'dropout_rate': dec_dropout_in,
+    'initializer': {
+        'type': 'normal_',
+        'kwargs': {
+            'mean': 0.0,
+            'std': embed_dim**-0.5,
+        },
+    }
+}
+
+max_pos = 200    # max sequence length in training data
+dec_pos_emb_hparams = {
+    'dim': hidden_size,
+}
+
+# due to the residual connection, the embed_dim should be equal to hidden_size
+trans_hparams = {
+    'output_layer_bias': False,
+    'embedding_dropout': embedding_dropout,
+    'residual_dropout': residual_dropout,
+    'num_blocks': num_blocks,
+    'dim': hidden_size,
+    'initializer': {
+        'type': 'variance_scaling_initializer',
+        'kwargs': {
+            'factor': 1.0,
+            'mode': 'FAN_AVG',
+            'uniform': True,
+        },
+    },
+    'multihead_attention': {
+        'dropout_rate': attention_dropout,
+        'num_heads': 8,
+        'num_units': hidden_size,
+        'output_dim': hidden_size
+    },
+    'poswise_feedforward': {
+        'name': 'fnn',
+        'layers': [
+            {
+                'type': 'Linear',
+                'kwargs': {
+                    "in_features": hidden_size,
+                    "out_features": hidden_size * 4,
+                    "bias": True,
+                },
+            },
+            {
+                'type': 'ReLU',
+            },
+            {
+                'type': 'Dropout',
+                'kwargs': {
+                    'p': relu_dropout,
+                }
+            },
+            {
+                'type': 'Linear',
+                'kwargs': {
+                    "in_features": hidden_size * 4,
+                    "out_features": hidden_size,
+                    "bias": True,
+                }
+            }
+        ],
+    }
+}
+
+# KL annealing
+kl_anneal_hparams = {
+    'warm_up': 10,
+    'start': 0.1
+}
+
+train_data_hparams = {
+    'num_epochs': 1,
+    'batch_size': batch_size,
+    'seed': 123,
+    'dataset': {
+        'files': './simple-examples/data/ptb.train.txt',
+        'vocab_file': './simple-examples/data/vocab.txt'
+    }
+}
+
+val_data_hparams = {
+    'num_epochs': 1,
+    'batch_size': batch_size,
+    'seed': 123,
+    'dataset': {
+        'files': './simple-examples/data/ptb.valid.txt',
+        'vocab_file': './simple-examples/data/vocab.txt'
+    }
+}
+
+test_data_hparams = {
+    'num_epochs': 1,
+    'batch_size': batch_size,
+    'dataset': {
+        'files': './simple-examples/data/ptb.test.txt',
+        'vocab_file': './simple-examples/data/vocab.txt'
+    }
+}
+
+opt_hparams = {
+    'optimizer': {
+        'type': 'Adam',
+        'kwargs': {
+            'lr': 0.001
+        }
+    },
+    'gradient_clip': {
+        "type": "clip_grad_norm_",
+        "kwargs": {
+            "max_norm": 5,
+            "norm_type": 2
+        }
+    }
+}

--- a/examples/vae_text/config_trans_yahoo.py
+++ b/examples/vae_text/config_trans_yahoo.py
@@ -15,8 +15,6 @@
 """VAE config.
 """
 
-# pylint: disable=invalid-name, too-few-public-methods, missing-docstring
-
 dataset = "yahoo"
 num_epochs = 100
 hidden_size = 512

--- a/examples/vae_text/config_trans_yahoo.py
+++ b/examples/vae_text/config_trans_yahoo.py
@@ -46,7 +46,7 @@ enc_cell_hparams = {
     "type": "LSTMCell",
     "kwargs": {
         "num_units": hidden_size,
-        "forget_bias": 0.
+        "bias": 0.
     },
     "dropout": {"output_keep_prob": 1. - enc_dropout_out},
     "num_layers": 1

--- a/examples/vae_text/config_trans_yahoo.py
+++ b/examples/vae_text/config_trans_yahoo.py
@@ -1,0 +1,191 @@
+# Copyright 2018 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VAE config.
+"""
+
+# pylint: disable=invalid-name, too-few-public-methods, missing-docstring
+
+dataset = "yahoo"
+num_epochs = 100
+hidden_size = 512
+dec_dropout_in = 0.
+enc_dropout_in = 0.
+enc_dropout_out = 0.
+batch_size = 32
+embed_dim = 512
+
+latent_dims = 32
+
+lr_decay_hparams = {
+    "init_lr": 0.001,
+    "threshold": 2,
+    "decay_factor": 0.5,
+    "max_decay": 5
+}
+
+
+relu_dropout = 0.2
+embedding_dropout = 0.2
+attention_dropout = 0.2
+residual_dropout = 0.2
+num_blocks = 3
+
+decoder_type = 'transformer'
+
+enc_cell_hparams = {
+    "type": "LSTMCell",
+    "kwargs": {
+        "num_units": hidden_size,
+        "forget_bias": 0.
+    },
+    "dropout": {"output_keep_prob": 1. - enc_dropout_out},
+    "num_layers": 1
+}
+
+enc_emb_hparams = {
+    'name': 'lookup_table',
+    "dim": embed_dim,
+    "dropout_rate": enc_dropout_in,
+    'initializer': {
+        'type': 'normal_',
+        'kwargs': {
+            'mean': 0.0,
+            'std': embed_dim**-0.5,
+        },
+    }
+}
+
+dec_emb_hparams = {
+    'name': 'lookup_table',
+    "dim": embed_dim,
+    "dropout_rate": dec_dropout_in,
+    'initializer': {
+        'type': 'normal_',
+        'kwargs': {
+            'mean': 0.0,
+            'std': embed_dim**-0.5,
+        },
+    }
+}
+
+
+max_pos = 300    # max sequence length in training data
+dec_pos_emb_hparams = {
+    'dim': hidden_size,
+}
+
+# due to the residual connection, the embed_dim should be equal to hidden_size
+trans_hparams = {
+    'output_layer_bias': False,
+    'embedding_dropout': embedding_dropout,
+    'residual_dropout': residual_dropout,
+    'num_blocks': num_blocks,
+    'dim': hidden_size,
+    'initializer': {
+        'type': 'variance_scaling_initializer',
+        'kwargs': {
+            'factor': 1.0,
+            'mode': 'FAN_AVG',
+            'uniform': True,
+        },
+    },
+    'multihead_attention': {
+        'dropout_rate': attention_dropout,
+        'num_heads': 8,
+        'num_units': hidden_size,
+        'output_dim': hidden_size
+    },
+    'poswise_feedforward': {
+        'name': 'fnn',
+       'layers': [
+            {
+                'type': 'Linear',
+                'kwargs': {
+                    "in_features": hidden_size,
+                    "out_features": hidden_size * 4,
+                    "bias": True,
+                },
+            },
+            {
+                'type': 'ReLU',
+            },
+            {
+                'type': 'Dropout',
+                'kwargs': {
+                    'p': relu_dropout,
+                }
+            },
+            {
+                'type': 'Linear',
+                'kwargs': {
+                    "in_features": hidden_size * 4,
+                    "out_features": hidden_size,
+                    "bias": True,
+                }
+            }
+        ],
+    }
+}
+
+# KL annealing
+kl_anneal_hparams = {
+    "warm_up": 10,
+    "start": 0.1
+}
+
+train_data_hparams = {
+    "num_epochs": 1,
+    "batch_size": batch_size,
+    "seed": 123,
+    "dataset": {
+        "files": './data/yahoo/yahoo.train.txt',
+        "vocab_file": './data/yahoo/vocab.txt'
+    }
+}
+
+val_data_hparams = {
+    "num_epochs": 1,
+    "batch_size": batch_size,
+    "seed": 123,
+    "dataset": {
+        "files": './data/yahoo/yahoo.valid.txt',
+        "vocab_file": './data/yahoo/vocab.txt'
+    }
+}
+
+test_data_hparams = {
+    "num_epochs": 1,
+    "batch_size": batch_size,
+    "dataset": {
+        "files": './data/yahoo/yahoo.test.txt',
+        "vocab_file": './data/yahoo/vocab.txt'
+    }
+}
+
+opt_hparams = {
+    'optimizer': {
+        'type': 'Adam',
+        'kwargs': {
+            'lr': 0.001
+        }
+    },
+    'gradient_clip': {
+        "type": "clip_grad_norm_",
+        "kwargs": {
+            "max_norm": 5,
+            "norm_type": 2
+        }
+    }
+}

--- a/examples/vae_text/prepare_data.py
+++ b/examples/vae_text/prepare_data.py
@@ -1,0 +1,61 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for downloading and preprocessing the PTB and Yohoo data.
+"""
+import os
+import argparse
+
+import texar.torch as tx
+
+
+def prepare_data(data_name):
+    """Prepare datasets.
+    Args:
+        data_path: the path to save the data
+        data_name: the name of dataset, "ptb" and "yahoo"
+            are currently supported
+    """
+    if data_name == "ptb":
+        data_path = "./simple-examples/data"
+        train_path = os.path.join(data_path, "ptb.train.txt")
+        if not os.path.exists(train_path):
+            url = 'http://www.fit.vutbr.cz/~imikolov/rnnlm/simple-examples.tgz'
+            tx.data.maybe_download(url, './', extract=True)
+
+        train_path = os.path.join(data_path, "ptb.train.txt")
+        vocab_path = os.path.join(data_path, "vocab.txt")
+        word_to_id = tx.data.make_vocab(
+            train_path, return_type="dict")
+
+        with open(vocab_path, 'w') as fvocab:
+            for word in word_to_id:
+                fvocab.write("%s\n" % word)
+
+    elif data_name == "yahoo":
+        data_path = "./data/yahoo"
+        train_path = os.path.join(data_path, "yahoo.train.txt")
+        if not os.path.exists(train_path):
+            url = 'https://drive.google.com/file/d/'\
+                  '13IsiffVjcQ-wrrbBGMwiG3sYf-DFxtXH/view?usp=sharing'
+            tx.data.maybe_download(url, path='./', filenames='yahoo.zip',
+                                   extract=True)
+    else:
+        raise ValueError('Unknown data: {}'.format(data_name))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='prepare data')
+    parser.add_argument('--data', type=str, help='dataset to prepare')
+    args = parser.parse_args()
+    prepare_data(args.data)

--- a/examples/vae_text/vae_train.py
+++ b/examples/vae_text/vae_train.py
@@ -210,7 +210,7 @@ class VAE(nn.Module):
 
     def decode(self,
                helper: Optional[Helper],
-               text_ids: Optional[torch.LongTensor]=None,
+               text_ids: Optional[torch.LongTensor] = None,
                latent_z: Optional[Tensor] = None,
                seq_lengths: Optional[Tensor] = None,
                max_decoding_length: Optional[int] = None) \

--- a/examples/vae_text/vae_train.py
+++ b/examples/vae_text/vae_train.py
@@ -29,7 +29,7 @@ import sys
 import time
 import argparse
 import importlib
-from typing import Optional, List, Any, Union, Dict, Tuple
+from typing import Optional, Any, Union, Dict, Tuple
 
 import numpy as np
 import torch
@@ -201,7 +201,7 @@ class VAE(nn.Module):
                latent_z: Optional[Tensor] = None,
                seq_lengths: Optional[Tensor] = None,
                max_decoding_length: Optional[int] = None) \
-            -> Union[tx.modules.BasicRNNDecoderOutput, 
+            -> Union[tx.modules.BasicRNNDecoderOutput,
                      tx.modules.TransformerDecoderOutput]:
 
         self._latent_z = latent_z
@@ -450,7 +450,8 @@ def main():
                 if decay_cnt == max_decay:
                     break
 
-    print(f'\nbest testing nll: {best_nll:.4f}, best testing ppl {best_ppl:.4f}\n')
+    print(f"\nbest testing nll: {best_nll:.4f},"
+          f"best testing ppl {best_ppl:.4f}\n")
 
 
 if __name__ == '__main__':

--- a/examples/vae_text/vae_train.py
+++ b/examples/vae_text/vae_train.py
@@ -42,14 +42,18 @@ import texar.torch.custom as custom
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--config', type=str, default=None,
-                    help="The config to use.")
-parser.add_argument('--mode', type=str, default='train',
-                    help="Train or predict.")
-parser.add_argument('--model', type=str, default=None,
-                    help="Model path for generating sentences.")
-parser.add_argument('--out', type=str, default=None,
-                    help="Generation output path.")
+parser.add_argument(
+    '--config', type=str, default=None,
+    help="The config to use.")
+parser.add_argument(
+    '--mode', type=str, default='train',
+    help="Train or predict.")
+parser.add_argument(
+    '--model', type=str, default=None,
+    help="Model path for generating sentences.")
+parser.add_argument(
+    '--out', type=str, default=None,
+    help="Generation output path.")
 
 args = parser.parse_args()
 
@@ -57,11 +61,9 @@ args = parser.parse_args()
 def kl_divergence(means: Tensor, logvars: Tensor) -> Tensor:
     """Compute the KL divergence between Gaussian distribution
     """
-
     kl_cost = -0.5 * (logvars - means ** 2 -
                       torch.exp(logvars) + 1.0)
     kl_cost = torch.mean(kl_cost, 0)
-
     return torch.sum(kl_cost)
 
 
@@ -106,6 +108,7 @@ class VAE(nn.Module):
                 token_pos_embedder=self._embed_fn_transformer,
                 hparams=config_model.trans_hparams)
             sum_state_size = self._config.dec_emb_hparams["dim"]
+
         else:
             raise ValueError("Decoder type must be 'lstm' or 'transformer'")
 

--- a/examples/vae_text/vae_train.py
+++ b/examples/vae_text/vae_train.py
@@ -1,0 +1,477 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Example for building the Variational Autoencoder.
+
+This is an impmentation of Variational Autoencoder for text generation
+
+To run:
+
+$ python vae_train.py
+
+Hyperparameters and data path may be specified in config_trans.py
+
+"""
+
+
+import os
+import sys
+import time
+import argparse
+import importlib
+from typing import Optional, List, Any, Union, Dict, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+import torch.nn as nn
+from torch.optim.lr_scheduler import ExponentialLR
+
+import texar.torch as tx
+from texar.torch.modules import BasicRNNDecoderOutput, TransformerDecoderOutput
+from texar.torch.custom import MultivariateNormalDiag
+from texar.torch.modules.decoders.decoder_helpers import Helper
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--config',
+                    type=str,
+                    default=None,
+                    help="The config to use.")
+parser.add_argument('--mode',
+                    type=str,
+                    default='train',
+                    help="Train or predict.")
+parser.add_argument('--model',
+                    type=str,
+                    default=None,
+                    help="Model path for generating sentences.")
+parser.add_argument('--out',
+                    type=str,
+                    default=None,
+                    help="Generation output path.")
+
+args = parser.parse_args()
+
+
+def kl_divergence(means: Tensor, logvars: Tensor) -> Tensor:
+    """Compute the KL divergence between Gaussian distribution
+    """
+
+    kl_cost = -0.5 * (logvars - means**2 -
+                      torch.exp(logvars) + 1.0)
+    kl_cost = torch.mean(kl_cost, 0)
+
+    return torch.sum(kl_cost)
+
+
+class VAE(nn.Module):
+    _latent_z: Tensor
+
+    def __init__(self,
+                 vocab_size: int, config_model):
+        super().__init__()
+        # Model architecture
+        self._config = config_model
+        self.encoder_w_embedder = tx.modules.WordEmbedder(
+            vocab_size=vocab_size, hparams=config_model.enc_emb_hparams)
+
+        self.encoder = tx.modules.UnidirectionalRNNEncoder(
+            input_size=self.encoder_w_embedder.dim,
+            hparams={
+                "rnn_cell": config_model.enc_cell_hparams,
+            })
+
+        self.decoder_w_embedder = tx.modules.WordEmbedder(
+            vocab_size=vocab_size, hparams=config_model.dec_emb_hparams)
+
+        if config_model.decoder_type == "lstm":
+            self.decoder = tx.modules.BasicRNNDecoder(
+                input_size=(self.decoder_w_embedder.dim +
+                    config_model.batch_size),
+                vocab_size=vocab_size,
+                token_embedder=self._embed_fn_rnn,
+                hparams={"rnn_cell": config_model.dec_cell_hparams})
+            sum_state_size = self.decoder.cell.hidden_size * 2
+
+        elif config_model.decoder_type == 'transformer':
+            # position embedding
+            self.decoder_p_embedder = tx.modules.SinusoidsPositionEmbedder(
+                position_size=config_model.max_pos,
+                hparams=config_model.dec_pos_emb_hparams)
+            # decoder
+            self.decoder = tx.modules.TransformerDecoder(
+                # tie word embedding with output layer
+                output_layer=self.decoder_w_embedder.embedding,
+                token_pos_embedder=self._embed_fn_transformer,
+                hparams=config_model.trans_hparams)
+            sum_state_size = self._config.dec_emb_hparams["dim"]
+        else:
+            raise ValueError("Decoder type must be 'lstm' or 'transformer'")
+
+        self.connector_mlp = tx.modules.MLPTransformConnector(
+            config_model.latent_dims * 2,
+            linear_layer_dim=self.encoder.cell.hidden_size * 2)
+
+        self.mlp_linear_layer = nn.Linear(
+            config_model.latent_dims,
+            sum_state_size)
+
+    def forward(self, data_batch: tx.data.Batch,
+                kl_weight: float, start_tokens: torch.LongTensor,
+                end_token: int) \
+            -> Dict:
+        # encoder -> connector -> decoder
+        text_ids = data_batch["text_ids"]
+        input_embed = self.encoder_w_embedder(text_ids)
+        _, encoder_states = self.encoder(
+            input_embed,
+            sequence_length=data_batch["length"])
+
+        mean_logvar = self.connector_mlp(encoder_states)
+        mean, logvar = torch.chunk(mean_logvar, 2, 1)
+        kl_loss = kl_divergence(mean, logvar)
+
+        dst = MultivariateNormalDiag(
+            loc=mean,
+            scale_diag=torch.exp(0.5 * logvar))
+
+        latent_z = dst.rsample()
+
+        labels = text_ids[:, 1:]
+        if self._config.decoder_type == "lstm":
+            helper = self.decoder.create_helper(
+                decoding_strategy="train_greedy",
+                start_tokens=start_tokens,
+                end_token=end_token,)
+        else:
+            helper = None
+
+        seq_lengths = data_batch["length"] - 1
+        # decode
+        outputs = self.decode(
+            helper=helper,
+            latent_z=latent_z,
+            seq_lengths=seq_lengths,
+            text_ids=text_ids[:, :-1],
+            )
+
+        logits = outputs.logits
+
+        # Losses & train ops
+        rc_loss = tx.losses.sequence_sparse_softmax_cross_entropy(
+            labels=labels,
+            logits=logits,
+            sequence_length=seq_lengths)
+
+        nll = rc_loss + kl_weight * kl_loss
+
+        ret = {
+            "nll": nll,
+            "kl_loss": kl_loss,
+            "rc_loss": rc_loss,
+            "lengths": seq_lengths
+        }
+
+        return ret
+
+    def _embed_fn_rnn(self, tokens: torch.LongTensor) -> Tensor:
+        r"""Generates word embeddings
+        """
+        embedding = self.decoder_w_embedder(
+            tokens)
+        latent_z = self._latent_z
+        if len(embedding.size()) > 2:
+            latent_z = torch.unsqueeze(latent_z, 0)
+            latent_z = latent_z.repeat([tokens.size(0), 1, 1])
+        return torch.cat([embedding, latent_z], dim=-1)
+
+    def _embed_fn_transformer(self,
+                              tokens: torch.LongTensor,
+                              positions: torch.LongTensor) -> Tensor:
+        r"""Generates word embeddings combined with positional embeddings
+        """
+        output_p_embed = self.decoder_p_embedder(positions)
+        output_w_embed = self.decoder_w_embedder(tokens)
+        output_w_embed = output_w_embed * \
+            self._config.hidden_size ** 0.5
+        output_embed = output_w_embed + output_p_embed
+        return output_embed
+
+    def decode(self,
+               helper: Optional[Helper],
+               text_ids: Optional[torch.LongTensor]=None,
+               latent_z: Optional[Tensor] = None,
+               seq_lengths: Optional[Tensor] = None,
+               max_decoding_length: Optional[int] = None) \
+            -> Union[BasicRNNDecoderOutput, TransformerDecoderOutput]:
+
+        self._latent_z = latent_z
+        fc_output = self.mlp_linear_layer(latent_z)
+
+        if self._config.decoder_type == "lstm":
+            decoder_initial_state_size = (self.decoder.cell.hidden_size,) * 2
+            decoder_states = torch.split(
+                fc_output, decoder_initial_state_size, dim=1)
+            outputs, _, _ = self.decoder(
+                initial_state=decoder_states,
+                inputs=text_ids,
+                helper=helper,
+                sequence_length=seq_lengths,
+                max_decoding_length=max_decoding_length)
+        else:
+            decoder_initial_state_size = torch.Size(
+                [1, self._config.dec_emb_hparams["dim"]])
+            decoder_states = torch.reshape(
+                fc_output, (-1, ) + decoder_initial_state_size)
+            outputs = self.decoder(
+                inputs=text_ids,
+                memory=decoder_states,
+                memory_sequence_length=torch.ones(decoder_states.size(0)),
+                helper=helper,
+                max_decoding_length=max_decoding_length)
+        return outputs
+
+
+class VAEData(tx.data.MonoTextData):
+    r""" Wrap `tx.data.MonoTextData` to implement data preprocessing.
+    """
+    def process(self, raw_example: List[str]) -> List[str]:
+        # Truncates sentences and appends BOS/EOS tokens.
+        words = super().process(raw_example[1:-1])
+        return words
+
+
+def main():
+    """Entrypoint.
+    """
+    config: Any = importlib.import_module(args.config)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    train_data = VAEData(config.train_data_hparams,
+                                      device=device)
+    val_data = VAEData(config.val_data_hparams,
+                                    device=device)
+    test_data = VAEData(config.test_data_hparams,
+                                     device=device)
+
+    iterator = tx.data.DataIterator(
+        {"train": train_data, "valid": val_data, "test": test_data})
+
+    opt_vars = {
+        'learning_rate': config.lr_decay_hparams["init_lr"],
+        'best_valid_nll': 1e100,
+        'steps_not_improved': 0,
+        'kl_weight': config.kl_anneal_hparams["start"]
+    }
+
+    decay_cnt = 0
+    max_decay = config.lr_decay_hparams["max_decay"]
+    decay_factor = config.lr_decay_hparams["decay_factor"]
+    decay_ts = config.lr_decay_hparams["threshold"]
+
+    save_dir = f"./models/{config.dataset}"
+
+    if not os.path.exists(save_dir):
+        os.makedirs(save_dir)
+
+    suffix = f"{config.dataset}_{config.decoder_type}Decoder.ckpt"
+
+    save_path = os.path.join(save_dir, suffix)
+
+    # KL term annealing rate
+    anneal_r = 1.0 / (config.kl_anneal_hparams["warm_up"] *
+        (len(train_data) / config.batch_size))
+
+    vocab = train_data.vocab
+    model = VAE(train_data.vocab.size, config)
+    model.to(device)
+
+    start_tokens = torch.full(
+            (config.batch_size,),
+            vocab.bos_token_id,
+            dtype=torch.long).to(device)
+    end_token = vocab.eos_token_id
+    optimizer = tx.core.get_optimizer(
+        params=model.parameters(),
+        hparams=config.opt_hparams)
+    scheduler = ExponentialLR(optimizer, decay_factor)
+
+    def _run_epoch(epoch: int, mode: str, display: int = 10) \
+            -> Tuple[Tensor, float]:
+        iterator.switch_to_dataset(mode)
+
+        if mode == 'train':
+            model.train()
+            opt_vars["kl_weight"] = min(
+                    1.0, opt_vars["kl_weight"] + anneal_r)
+
+            kl_weight = opt_vars["kl_weight"]
+        else:
+            model.eval()
+            kl_weight = 1.0
+        step = 0
+        start_time = time.time()
+        num_words = 0
+        nll_total = 0.
+
+        avg_rec = tx.utils.AverageRecorder()
+        for batch in iterator:
+
+            ret = model(batch, kl_weight, start_tokens, end_token)
+            if mode == "train":
+                opt_vars["kl_weight"] = min(
+                    1.0, opt_vars["kl_weight"] + anneal_r)
+                kl_weight = opt_vars["kl_weight"]
+                ret["nll"].backward()
+                optimizer.step()
+                optimizer.zero_grad()
+
+            batch_size = len(ret["lengths"])
+            num_words += torch.sum(ret["lengths"]).item()
+            nll_total += ret["nll"].item() * batch_size
+            avg_rec.add(
+                [ret["nll"].item(),
+                 ret["kl_loss"].item(),
+                 ret["rc_loss"].item()],
+                batch_size)
+            if step % display == 0 and mode == 'train':
+                nll = avg_rec.avg(0)
+                klw = opt_vars["kl_weight"]
+                KL = avg_rec.avg(1)
+                rc = avg_rec.avg(2)
+                log_ppl = nll_total / num_words
+                ppl = np.exp(log_ppl)
+                time_cost = time.time() - start_time
+
+                print(f"{mode}: epoch {epoch}, step {step}, nll {nll:.4f}, "
+                      f"klw {klw:.4f}, KL {KL:.4f}, rc {rc:.4f}, "
+                      f"log_ppl {log_ppl:.4f}, ppl {ppl:.4f}, "
+                      f"time_cost {time_cost:.1f}", flush=True)
+
+            step += 1
+
+        nll = avg_rec.avg(0)
+        KL = avg_rec.avg(1)
+        rc = avg_rec.avg(2)
+        log_ppl = nll_total / num_words
+        ppl = np.exp(log_ppl)
+        print(f"\n{mode}: epoch {epoch}, nll {nll:.4f}, KL {KL:.4f}, "
+              f"rc {rc:.4f}, log_ppl {log_ppl:.4f}, ppl {ppl:.4f}")
+        return nll, ppl
+
+    @torch.no_grad()
+    def _generate(start_tokens: torch.LongTensor,
+                  end_token: int,
+                  filename: Optional[str] = None):
+        ckpt = torch.load(args.model)
+        model.load_state_dict(ckpt['model'])
+        model.eval()
+
+        batch_size = train_data.batch_size
+
+        dst = MultivariateNormalDiag(
+            loc=torch.zeros([batch_size, config.latent_dims]),
+            scale_diag=torch.ones([batch_size, config.latent_dims]))
+
+        latent_z = dst.rsample().to(device)
+
+        if config.decoder_type == "lstm":
+            helper = model.decoder.create_helper(
+                decoding_strategy='infer_sample',
+                start_tokens=start_tokens,
+                end_token=end_token)
+            outputs = model.decode(
+                helper=helper,
+                latent_z=latent_z,
+                max_decoding_length=100)
+        else:
+            helper = model.decoder.create_helper(
+                decoding_strategy='infer_sample',
+                start_tokens=start_tokens,
+                end_token=end_token)
+            outputs, _ = model.decode(
+                helper=helper,
+                max_decoding_length=100)
+
+        sample_tokens = vocab.map_ids_to_tokens_py(outputs.sample_id.cpu())
+
+        if filename is None:
+            fh = sys.stdout
+        else:
+            fh = open(filename, 'w', encoding='utf-8')
+
+        for sent in sample_tokens:
+            sent = tx.utils.compat_as_text(list(sent))
+            end_id = len(sent)
+            if vocab.eos_token in sent:
+                end_id = sent.index(vocab.eos_token)
+            fh.write(' '.join(sent[:end_id + 1]) + '\n')
+
+        print('Output done')
+        fh.close()
+
+    if args.mode == "predict":
+        _generate(start_tokens, end_token, args.out)
+        return
+    # Counts trainable parameters
+    total_parameters = 0
+    for _, variable in model.named_parameters():
+        size = variable.size()
+        total_parameters += np.prod(size)
+    print(f"{total_parameters} total parameters")
+
+    best_nll = best_ppl = 0.
+
+    for epoch in range(config.num_epochs):
+        _, _ = _run_epoch(epoch, 'train', display=200)
+        val_nll, _ = _run_epoch(epoch, 'valid')
+        test_nll, test_ppl = _run_epoch(epoch, 'test')
+
+        if val_nll < opt_vars['best_valid_nll']:
+            opt_vars['best_valid_nll'] = val_nll
+            opt_vars['steps_not_improved'] = 0
+            best_nll = test_nll
+            best_ppl = test_ppl
+
+            states = {
+                "model": model.state_dict(),
+                "optimizer": optimizer.state_dict(),
+                "scheduler": scheduler.state_dict()
+            }
+            torch.save(states, save_path)
+        else:
+            opt_vars['steps_not_improved'] += 1
+            if opt_vars['steps_not_improved'] == decay_ts:
+                old_lr = opt_vars['learning_rate']
+                opt_vars['learning_rate'] *= decay_factor
+                opt_vars['steps_not_improved'] = 0
+                new_lr = opt_vars['learning_rate']
+                ckpt = torch.load(save_path)
+                model.load_state_dict(ckpt['model'])
+                optimizer.load_state_dict(ckpt['optimizer'])
+                scheduler.load_state_dict(ckpt['scheduler'])
+                scheduler.step()
+                print(f"-----\nchange lr, old lr: {old_lr}, "
+                      f"new lr: {new_lr}\n-----")
+
+                decay_cnt += 1
+                if decay_cnt == max_decay:
+                    break
+
+    print('\nbest testing nll: %.4f, best testing ppl %.4f\n' %
+        (best_nll, best_ppl))
+
+
+if __name__ == '__main__':
+    main()

--- a/texar/torch/__init__.py
+++ b/texar/torch/__init__.py
@@ -27,3 +27,4 @@ from texar.torch import modules
 from texar.torch import utils
 from texar.torch.hyperparams import *
 from texar.torch.module_base import *
+from texar.torch.custom import *

--- a/texar/torch/__init__.py
+++ b/texar/torch/__init__.py
@@ -27,4 +27,3 @@ from texar.torch import modules
 from texar.torch import utils
 from texar.torch.hyperparams import *
 from texar.torch.module_base import *
-from texar.torch.custom import *

--- a/texar/torch/custom/__init__.py
+++ b/texar/torch/custom/__init__.py
@@ -4,3 +4,4 @@ Custom modules in Texar
 
 from texar.torch.custom.activation import *
 from texar.torch.custom.initializers import *
+from texar.torch.custom.distributions import *

--- a/texar/torch/custom/distributions.py
+++ b/texar/torch/custom/distributions.py
@@ -1,0 +1,7 @@
+from torch.distributions import Normal, Independent
+
+
+def MultivariateNormalDiag(loc, scale_diag):
+    if loc.dim() < 1:
+        raise ValueError("loc must be at least one-dimensional.")
+    return Independent(Normal(loc, scale_diag), 1)

--- a/texar/torch/data/vocabulary.py
+++ b/texar/torch/data/vocabulary.py
@@ -140,11 +140,10 @@ class Vocab:
                  self._unk_token] + vocab
         # Must make sure this is consistent with the above line
         vocab_size = len(vocab)
-        vocab_idx = np.arange(vocab_size)
 
         # Creates python maps to interface with python code
-        id_to_token_map_py = dict(zip(vocab_idx, vocab))
-        token_to_id_map_py = dict(zip(vocab, vocab_idx))
+        id_to_token_map_py = dict(zip(range(vocab_size), vocab))
+        token_to_id_map_py = dict(zip(vocab, range(vocab_size)))
 
         return id_to_token_map_py, token_to_id_map_py
 

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from torch import nn
+from torch import nn, split
 from torch.distributions.distribution import Distribution
 
 from texar.torch.core import get_activation_fn
@@ -94,8 +94,8 @@ def _sum_output_size(output_size: OutputSize) -> int:
             size_list[i] = np.prod([dim for dim in shape])
     else:
         size_list = flat_output_size
-    sum_output_size = sum(size_list)
-    return sum_output_size
+    ret = sum(size_list)
+    return ret
 
 
 def _mlp_transform(inputs: TensorStruct,
@@ -128,12 +128,8 @@ def _mlp_transform(inputs: TensorStruct,
     """
     # Flatten inputs
     flat_input = nest.flatten(inputs)
-    if len(flat_input[0].size()) == 1:
-        batch_size = 1
-    else:
-        batch_size = flat_input[0].size(0)
-    flat_input = [x.view(-1, x.size(-1)) for x in flat_input]
-    concat_input = torch.cat(flat_input, 0)
+    flat_input = [x.view(-1, np.prod(list(x.size())[1:])) for x in flat_input]
+    concat_input = torch.cat(flat_input, 1)
     # Get output dimension
     flat_output_size = nest.flatten(output_size)
 
@@ -144,23 +140,19 @@ def _mlp_transform(inputs: TensorStruct,
     else:
         size_list = flat_output_size
 
-    fc_output = concat_input
     if linear_layer is not None:
-        fc_output = linear_layer(fc_output)
+        fc_output = linear_layer(concat_input)
     if activation_fn is not None:
         fc_output = activation_fn(fc_output)
+    elif linear_layer is None and activation_fn is None:
+        fc_output = concat_input
+    flat_output = split(fc_output, size_list, dim=1)    # type: ignore
 
-    flat_output = torch.split(fc_output, size_list, dim=1)
     flat_output = list(flat_output)
-    for i, _ in enumerate(flat_output):
-        final_state = flat_output[i].size(-1)
-        flat_output[i] = flat_output[i].view(batch_size, -1, final_state)
-        flat_output[i] = torch.squeeze(flat_output[i], 1)
-
     if isinstance(flat_output_size[0], torch.Size):
         for (i, shape) in enumerate(flat_output_size):
             flat_output[i] = torch.reshape(
-                flat_output[i], (-1,) + shape)
+                flat_output[i], (-1, ) + shape)
 
     output = nest.pack_sequence_as(structure=output_size,
                                    flat_sequence=flat_output)

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -140,13 +140,13 @@ def _mlp_transform(inputs: TensorStruct,
     else:
         size_list = flat_output_size
 
+    fc_output = concat_input
     if linear_layer is not None:
-        fc_output = linear_layer(concat_input)
+        fc_output = linear_layer(fc_output)
     if activation_fn is not None:
         fc_output = activation_fn(fc_output)
-    elif linear_layer is None and activation_fn is None:
-        fc_output = concat_input
-    flat_output = split(fc_output, size_list, dim=1)
+
+    flat_output = torch.split(fc_output, size_list, dim=1)
     flat_output = list(flat_output)
     if isinstance(flat_output_size[0], torch.Size):
         for (i, shape) in enumerate(flat_output_size):

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -117,6 +117,7 @@ def _mlp_transform(inputs: TensorStruct,
         output_size: Can be an ``Integer``, a ``torch.Size``, or a (nested)
             ``tuple`` of ``Integers`` or ``torch.Size``.
         activation_fn: Activation function applied to the output.
+
     :returns:
         If :attr:`output_size` is an ``Integer`` or a ``torch.Size``,
         returns a ``Tensor`` of shape ``[batch_size, *, output_size]``.

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -152,7 +152,7 @@ def _mlp_transform(inputs: TensorStruct,
     if isinstance(flat_output_size[0], torch.Size):
         for (i, shape) in enumerate(flat_output_size):
             flat_output[i] = torch.reshape(
-                flat_output[i], (-1, ) + shape)
+                flat_output[i], (-1,) + shape)
 
     output = nest.pack_sequence_as(structure=output_size,
                                    flat_sequence=flat_output)

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from torch import nn, split
+from torch import nn
 from torch.distributions.distribution import Distribution
 
 from texar.torch.core import get_activation_fn

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -105,6 +105,7 @@ def _mlp_transform(inputs: TensorStruct,
                    ) -> Any:
     r"""Transforms inputs through a fully-connected layer that creates
     the output with specified size.
+
     Args:
         inputs: A ``Tensor`` of shape ``[batch_size, ..., finale_state]``
             (i.e., batch-major), or a (nested) tuple of such elements.

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -146,8 +146,7 @@ def _mlp_transform(inputs: TensorStruct,
         fc_output = activation_fn(fc_output)
     elif linear_layer is None and activation_fn is None:
         fc_output = concat_input
-    flat_output = split(fc_output, size_list, dim=1)    # type: ignore
-
+    flat_output = split(fc_output, size_list, dim=1)
     flat_output = list(flat_output)
     if isinstance(flat_output_size[0], torch.Size):
         for (i, shape) in enumerate(flat_output_size):

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -131,7 +131,7 @@ def _mlp_transform(inputs: TensorStruct,
     else:
         batch_size = flat_input[0].size(0)
     flat_input = [x.view(-1, x.size(-1)) for x in flat_input]
-    concat_input = torch.cat(flat_input, 0)
+    concat_input = torch.cat(flat_input, 1)
     # Get output dimension
     flat_output_size = nest.flatten(output_size)
 

--- a/texar/torch/modules/decoders/rnn_decoder_base.py
+++ b/texar/torch/modules/decoders/rnn_decoder_base.py
@@ -201,7 +201,10 @@ class RNNDecoderBase(DecoderBase[State, Output]):
             -> Tuple[torch.ByteTensor, torch.Tensor, Optional[State]]:
         initial_finished, initial_inputs = helper.initialize(
             self.embed_tokens, inputs, sequence_length)
-        state = initial_state or self._cell.init_batch()
+        if initial_state is None:
+            state = self._cell.init_batch()
+        else:
+            state = initial_state
         return (initial_finished, initial_inputs, state)
 
     def step(self, helper: Helper, time: int,


### PR DESCRIPTION
* Port vae_text from texar-TF.

* Add external distribution
MultivariateNormalDiag.

* Add preprocessing for data batch.

* Modify None checking condition for initial_state in
RNNDecoderBase.

* Modify max_pos for config_trans_yahoo.py.

* Modify connectors mlp function.

* Refactor vae_text training & generation decoder.

* Refactor vae_text decoder embeddings.

* Refactor to import `texar.torch`.

* Polish code.