### PR TITLE
Fix FileNotFoundError when calling `bleu_moses` from installed package

### DIFF
--- a/examples/gpt-2/README.md
+++ b/examples/gpt-2/README.md
@@ -45,7 +45,7 @@ generates continuation of the context. The example supports both Top-K and Top-P
 
 ```bash
 python gpt2_generate_main.py --interactive \
-    --max-decoding_length=100 \
+    --max-decoding-length=100 \
     --temperature=0.7 \
     --top-k=40
 ```

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ setuptools.setup(
         'extras': ['Pillow>=3.0'],
     },
     package_data={
-        "texar": [
-            "../bin/utils/multi-bleu.perl",
+        "texar.torch": [
+            "../../bin/utils/multi-bleu.perl",
         ]
     },
     classifiers=[


### PR DESCRIPTION
Fix `FileNotFoundError` for `multi-bleu.perl` when `texar-pytorch` is packed as package.