### PR TITLE
Enhancement of Convolution Networks

### DIFF
--- a/texar/torch/modules/classifiers/conv_classifiers.py
+++ b/texar/torch/modules/classifiers/conv_classifiers.py
@@ -175,8 +175,10 @@ class Conv1DClassifier(ClassifierBase):
                 from inputs automatically.
             data_format (optional): Data type of the input tensor. If
                 ``channels_last``, the last dimension will be treated as channel
-                dimension. If ``channels_first``, first dimension will be
-                treated as channel dimension. Defaults to None.
+                dimension so the size of the :attr:`input` should be
+                `[batch_size, X, channel]`. If ``channels_first``, first
+                dimension will be treated as channel dimension so the size
+                should be `[batch_size, channel, X]`. Defaults to None.
                 If None, the value will be picked from hyperparameters.
 
         Returns:

--- a/texar/torch/modules/classifiers/conv_classifiers.py
+++ b/texar/torch/modules/classifiers/conv_classifiers.py
@@ -69,9 +69,12 @@ class Conv1DClassifier(ClassifierBase):
         self._num_classes = self._hparams.num_classes
         if self._num_classes > 0:
             if self._hparams.num_dense_layers <= 0:
+                if in_features is None:
+                    raise ValueError("'in_features' is required for logits "
+                                     "layer when 'num_dense_layers' <= 0")
                 self._encoder.append_layer({"type": "Flatten"})
                 ones = torch.ones(1, in_channels, in_features)
-                input_size = self._encoder._infer_dense_layer_input_size(ones)
+                input_size = self._encoder._infer_dense_layer_input_size(ones)  # pylint: disable=protected-access
                 self.hparams.logit_layer_kwargs.in_features = input_size[1]
 
             logit_kwargs = self._hparams.logit_layer_kwargs
@@ -170,11 +173,11 @@ class Conv1DClassifier(ClassifierBase):
                 first be masked out before feeding to the layers.
             dtype (optional): Type of the inputs. If not provided, infers
                 from inputs automatically.
-            data_format(optional): Data type of the input tensor. If
+            data_format (optional): Data type of the input tensor. If
                 ``channels_last``, the last dimension will be treated as channel
-                 dimension. If ``channels_first``, first dimension will be
-                 treated as channel dimension. Defaults to None.
-                 If None, the value will be picked from hparams.
+                dimension. If ``channels_first``, first dimension will be
+                treated as channel dimension. Defaults to None.
+                If None, the value will be picked from hyperparameters.
 
         Returns:
             A tuple ``(logits, pred)``, where

--- a/texar/torch/modules/classifiers/conv_classifiers.py
+++ b/texar/torch/modules/classifiers/conv_classifiers.py
@@ -70,6 +70,9 @@ class Conv1DClassifier(ClassifierBase):
         if self._num_classes > 0:
             if self._hparams.num_dense_layers <= 0:
                 self._encoder.append_layer({"type": "Flatten"})
+                ones = torch.ones(1, in_channels, in_features)
+                input_size = self._encoder._infer_dense_layer_input_size(ones)
+                self.hparams.logit_layer_kwargs.in_features = input_size[1]
 
             logit_kwargs = self._hparams.logit_layer_kwargs
             if logit_kwargs is None:
@@ -146,7 +149,8 @@ class Conv1DClassifier(ClassifierBase):
     def forward(self,  # type:ignore
                 input: torch.Tensor,
                 sequence_length: Union[torch.LongTensor, List[int]] = None,
-                dtype: Optional[torch.dtype] = None) \
+                dtype: Optional[torch.dtype] = None,
+                data_format: Optional[str] = None) \
             -> Tuple[torch.Tensor, torch.Tensor]:
         r"""Feeds the inputs through the network and makes classification.
 
@@ -166,6 +170,11 @@ class Conv1DClassifier(ClassifierBase):
                 first be masked out before feeding to the layers.
             dtype (optional): Type of the inputs. If not provided, infers
                 from inputs automatically.
+            data_format(optional): Data type of the input tensor. If
+                ``channels_last``, the last dimension will be treated as channel
+                 dimension. If ``channels_first``, first dimension will be
+                 treated as channel dimension. Defaults to None.
+                 If None, the value will be picked from hparams.
 
         Returns:
             A tuple ``(logits, pred)``, where
@@ -180,7 +189,7 @@ class Conv1DClassifier(ClassifierBase):
               ``{0, 1}``.
         """
         logits = self._encoder(input, sequence_length=sequence_length,
-                               dtype=dtype)
+                               dtype=dtype, data_format=data_format)
 
         num_classes = self._hparams.num_classes
         is_binary = num_classes == 1

--- a/texar/torch/modules/classifiers/conv_classifiers_test.py
+++ b/texar/torch/modules/classifiers/conv_classifiers_test.py
@@ -28,9 +28,25 @@ class Conv1DClassifierTest(unittest.TestCase):
         self.assertEqual(logits.shape, torch.Size([128, 2]))
         self.assertEqual(pred.shape, torch.Size([128]))
 
-        # case 1
+        # case 2
         inputs = torch.randn(128, 32, 300)
         hparams = {
+            "num_classes": 10,
+            "logit_layer_kwargs": {"bias": False}
+        }
+        classifier = Conv1DClassifier(in_channels=inputs.shape[1],
+                                      in_features=inputs.shape[2],
+                                      hparams=hparams)
+        logits, pred = classifier(inputs)
+        self.assertEqual(logits.shape, torch.Size([128, 10]))
+        self.assertEqual(pred.shape, torch.Size([128]))
+
+    def test_classifier_with_no_dense_layer(self):
+        """Tests classifier with no dense layer.
+        """
+        inputs = torch.randn(128, 32, 300)
+        hparams = {
+            "num_dense_layers": 0,
             "num_classes": 10,
             "logit_layer_kwargs": {"bias": False}
         }

--- a/texar/torch/modules/networks/conv_networks.py
+++ b/texar/torch/modules/networks/conv_networks.py
@@ -629,7 +629,19 @@ class Conv1DNetwork(FeedForwardNetworkBase):
     @property
     def output_size(self) -> int:
         if self.hparams.num_dense_layers <= 0:
-            return self._hparams.out_channels * len(self._hparams.kernel_size)
+            out_channels = self._hparams.out_channels
+            if not isinstance(out_channels, (list, tuple)):
+                out_channels = [out_channels]
+            nconv = self._hparams.num_conv_layers
+            if nconv == 1:
+                kernel_size = _to_list(self._hparams.kernel_size)
+                if not isinstance(kernel_size[0], (list, tuple)):
+                    kernel_size = [kernel_size]
+            elif nconv > 1:
+                kernel_size = _to_list(self._hparams.kernel_size,
+                                       'kernel_size', nconv)
+                kernel_size = [_to_list(ks) for ks in kernel_size]
+            return out_channels[-1] * len(kernel_size[-1])
         else:
             out_features = self._hparams.out_features
             if isinstance(out_features, (list, tuple)):

--- a/texar/torch/modules/networks/conv_networks.py
+++ b/texar/torch/modules/networks/conv_networks.py
@@ -605,8 +605,8 @@ class Conv1DNetwork(FeedForwardNetworkBase):
 
             output = super().forward(input)
 
-            # transpose only when no dense layers
-            if self._hparams.num_dense_layers <= 0:
+            # transpose only when tensors are 3D
+            if output.dim() == 3:
                 output = output.permute(0, 2, 1)
         else:
             raise ValueError("Invalid 'data_format'")

--- a/texar/torch/modules/networks/conv_networks.py
+++ b/texar/torch/modules/networks/conv_networks.py
@@ -583,6 +583,9 @@ class Conv1DNetwork(FeedForwardNetworkBase):
         Returns:
             The output of the final layer.
         """
+        if input.dim() != 3:
+            raise ValueError("'input' should be a 3D tensor.")
+
         if data_format is None:
             data_format = self.hparams["data_format"]
 

--- a/texar/torch/modules/networks/conv_networks.py
+++ b/texar/torch/modules/networks/conv_networks.py
@@ -351,8 +351,8 @@ class Conv1DNetwork(FeedForwardNetworkBase):
             other_kwargs = _to_list(other_kwargs, "other_kwargs", npool)
         elif isinstance(other_kwargs, (list, tuple)):
             if len(other_kwargs) != npool:
-                raise ValueError("len(hparams['other_pool_kwargs']) must equal "
-                                 "'num_conv_layers'")
+                raise ValueError("The length of hparams['other_pool_kwargs'] "
+                                 "must equal 'num_conv_layers'")
         else:
             raise ValueError("hparams['other_pool_kwargs'] must be either a "
                              "dict or list/tuple")
@@ -396,8 +396,8 @@ class Conv1DNetwork(FeedForwardNetworkBase):
             other_kwargs = _to_list(other_kwargs, "other_conv_kwargs", nconv)
         elif isinstance(other_kwargs, (list, tuple)):
             if len(other_kwargs) != nconv:
-                raise ValueError("len(hparams['other_conv_kwargs']) must be "
-                                 "equal to num_conv_layers")
+                raise ValueError("The length of hparams['other_conv_kwargs'] "
+                                 "must be equal to 'num_conv_layers'")
         else:
             raise ValueError("hparams['other_conv_kwargs'] must be a either "
                              "a dict or a list.")
@@ -417,8 +417,9 @@ class Conv1DNetwork(FeedForwardNetworkBase):
                                            len(kernel_size[i]))
             elif (isinstance(other_kwargs[i], (list, tuple))
                   and len(other_kwargs[i]) != kernel_size[i]):
-                raise ValueError("len(hparams['other_conv_kwargs'][i]) must be "
-                                 "equal to len(hparams['kernel_size'][i])")
+                raise ValueError("The length of hparams['other_conv_kwargs'][i]"
+                                 " must be equal to the length of "
+                                 "hparams['kernel_size'][i]")
             for idx, ks_ij in enumerate(kernel_size[i]):
                 name = uniquify_str("conv_%d" % (i + 1), names)
                 names.append(name)
@@ -574,8 +575,10 @@ class Conv1DNetwork(FeedForwardNetworkBase):
                 infers from inputs automatically.
             data_format (optional): Data type of the input tensor. If
                 ``channels_last``, the last dimension will be treated as channel
-                dimension. If ``channels_first``, first dimension will be
-                treated as channel dimension. Defaults to None.
+                dimension so the size of the :attr:`input` should be
+                `[batch_size, X, channel]`. If ``channels_first``, first
+                dimension will be treated as channel dimension so the size
+                should be `[batch_size, channel, X]`. Defaults to None.
                 If None, the value will be picked from hyperparameters.
         Returns:
             The output of the final layer.

--- a/texar/torch/modules/networks/conv_networks.py
+++ b/texar/torch/modules/networks/conv_networks.py
@@ -165,6 +165,7 @@ class Conv1DNetwork(FeedForwardNetworkBase):
                  For example, the default values will create 3 convolution
                  layers, each of which has kernel size of 3, 4, and 5,
                  respectively, and has output channel 128.
+
                - If `"num_conv_layers"` > 1, this must be a list of length
                  ``"num_conv_layers"``. Each element can be an ``int`` or a
                  ``int`` list of arbitrary length denoting the kernel size of
@@ -185,6 +186,7 @@ class Conv1DNetwork(FeedForwardNetworkBase):
 
                - If a dict, the same dict is applied to all the convolution
                  layers.
+
                - If a list, the length must equal ``"num_conv_layers"``. This
                  list can contain nested lists. If the convolution layer at
                  index i has multiple kernel sizes, then the corresponding
@@ -225,8 +227,8 @@ class Conv1DNetwork(FeedForwardNetworkBase):
            `"other_pool_kwargs"`: list or dict, optional
                Other keyword arguments for pooling layer class constructor.
 
-               - If a dict, the same dict is applied to all the pooling
-                 layers.
+               - If a dict, the same dict is applied to all the pooling layers.
+
                - If a list, the length must equal ``"num_conv_layers"``. The
                  pooling arguments for layer i will be the element at index i
                  from this list.
@@ -570,11 +572,11 @@ class Conv1DNetwork(FeedForwardNetworkBase):
                 layers.
             dtype (optional): Type of the inputs. If not provided,
                 infers from inputs automatically.
-            data_format(optional): Data type of the input tensor. If
+            data_format (optional): Data type of the input tensor. If
                 ``channels_last``, the last dimension will be treated as channel
-                 dimension. If ``channels_first``, first dimension will be
-                 treated as channel dimension. Defaults to None.
-                 If None, the value will be picked from hparams.
+                dimension. If ``channels_first``, first dimension will be
+                treated as channel dimension. Defaults to None.
+                If None, the value will be picked from hyperparameters.
         Returns:
             The output of the final layer.
         """

--- a/texar/torch/modules/networks/conv_networks_test.py
+++ b/texar/torch/modules/networks/conv_networks_test.py
@@ -68,6 +68,7 @@ class Conv1DNetworkTest(unittest.TestCase):
         outputs_2 = network_2(inputs_2)
         self.assertEqual(outputs_2.shape, torch.Size([128, 10]))
         self.assertEqual(outputs_2.size(-1), network_2.output_size)
+
         # test whether concatenation happens along channel dim when feature dim
         # has been reduced
         hparams = {
@@ -100,6 +101,82 @@ class Conv1DNetworkTest(unittest.TestCase):
         self.assertEqual(outputs_3.shape,
                          torch.Size([128, num_of_kernels * out_channels]))
         self.assertEqual(outputs_3.size(-1), network_3.output_size)
+
+    def test_conv_and_pool_kwargs(self):
+
+        inputs = torch.ones([128, 64, 300])
+        hparams = {
+            # Conv layers
+            "num_conv_layers": 2,
+            "out_channels": 128,
+            "kernel_size": [[3, 4, 5], 4],
+            "other_conv_kwargs": [{"padding": 0}, {"padding": 0}],
+            # Pooling layers
+            "pooling": "AvgPool1d",
+            "pool_size": 2,
+            "pool_stride": 1,
+            "other_pool_kwargs": {},
+            # Dense layers
+            "num_dense_layers": 3,
+            "out_features": [128, 128, 10],
+            "dense_activation": "ReLU",
+            "other_dense_kwargs": None,
+            # Dropout
+            "dropout_conv": [0, 1, 2],
+            "dropout_dense": 2
+        }
+
+        network = Conv1DNetwork(in_channels=inputs.shape[1],
+                                  in_features=inputs.shape[2],
+                                  hparams=hparams)
+        # dropout-merge-dropout-(Sequential(Conv, ReLU))-avgpool-dropout-
+        # flatten-(Sequential(Linear,ReLU))-(Sequential(Linear,ReLU))-dropout
+        # -linear
+        self.assertEqual(len(network.layers), 1 + 1 + 1 + 3 + 4 + 1)
+        self.assertIsInstance(
+            network.layer_by_name("MergeLayer"), MergeLayer)
+        for layer in network.layers[1].layers:
+            self.assertIsInstance(layer, nn.Sequential)
+
+    def test_channel_dimension(self):
+        inputs = torch.ones([128, 64, 300])
+        hparams = {
+            # Conv layers
+            "num_conv_layers": 2,
+            "out_channels": 128,
+            "kernel_size": [[3, 4, 5], 4],
+            "other_conv_kwargs": [{"padding": 0}, {"padding": 0}],
+            # Pooling layers
+            "pooling": "AvgPool1d",
+            "pool_size": 2,
+            "pool_stride": 1,
+            "other_pool_kwargs": {},
+            # Dense layers
+            "num_dense_layers": 3,
+            "out_features": [128, 128, 10],
+            "dense_activation": "ReLU",
+            "other_dense_kwargs": None,
+            # Dropout
+            "dropout_conv": [0, 1, 2],
+            "dropout_dense": 2
+        }
+
+        network = Conv1DNetwork(in_channels=inputs.shape[1],
+                                in_features=inputs.shape[2],
+                                hparams=hparams)
+        # dropout-merge-dropout-(Sequential(Conv, ReLU))-avgpool-dropout-
+        # flatten-(Sequential(Linear,ReLU))-(Sequential(Linear,ReLU))-dropout
+        # -linear
+        self.assertEqual(len(network.layers), 1 + 1 + 1 + 3 + 4 + 1)
+        self.assertIsInstance(
+            network.layer_by_name("MergeLayer"), MergeLayer)
+        for layer in network.layers[1].layers:
+            self.assertIsInstance(layer, nn.Sequential)
+
+        inputs_t = torch.ones([128, 300, 64])
+        output = network(inputs_t, data_format="channels_last")
+        self.assertEqual(output.shape, torch.Size([128, 10]))
+        self.assertEqual(output.size(-1), network.output_size)
 
 
 if __name__ == "__main__":

--- a/texar/torch/modules/networks/conv_networks_test.py
+++ b/texar/torch/modules/networks/conv_networks_test.py
@@ -102,6 +102,13 @@ class Conv1DNetworkTest(unittest.TestCase):
                          torch.Size([128, num_of_kernels * out_channels]))
         self.assertEqual(outputs_3.size(-1), network_3.output_size)
 
+        # test for channels last tensors
+        inputs_3 = inputs_3.permute(0, 2, 1)
+        outputs_3 = network_3(inputs_3, data_format="channels_last")
+        self.assertEqual(outputs_3.shape,
+                         torch.Size([128, num_of_kernels * out_channels]))
+        self.assertEqual(outputs_3.size(-1), network_3.output_size)
+
     def test_conv_and_pool_kwargs(self):
 
         inputs = torch.ones([128, 64, 300])

--- a/texar/torch/modules/networks/conv_networks_test.py
+++ b/texar/torch/modules/networks/conv_networks_test.py
@@ -91,10 +91,10 @@ class Conv1DNetworkTest(unittest.TestCase):
             "dropout_dense": []
         }
 
-        network_3 = Conv1DNetwork(in_channels=inputs_2.shape[1],
-                                  in_features=inputs_2.shape[2],
+        inputs_3 = torch.ones([128, 64, 300])
+        network_3 = Conv1DNetwork(in_channels=inputs_3.shape[1],
+                                  in_features=inputs_3.shape[2],
                                   hparams=hparams)
-        inputs_3 = inputs_2
         outputs_3 = network_3(inputs_3)
         num_of_kernels = len(hparams["kernel_size"])
         out_channels = hparams["out_channels"]


### PR DESCRIPTION
This PR 

- Corrects a few mistakes in the docs for Convolution Networks

- Adds `data_format` capability. User can now use `channels_first` and `channels_last` tensors. This option can be passed in forward function. If not passed, it will be picked from hyperparameters

- Handles the difference in `data_format` requirements between convolution network and `mask_sequences` [This was an existing issue which was unnoticed]

- Makes `other_conv_kwargs` and `other_pool_kwargs` accept list as well as dict. If dict, the same property is applied to all layers. If list, then individual layers get their own `kwargs`

- Fixes a bug - When `num_dense_layers < 0`, `in_features` of logits layer equals the `out_features` of `Flatten` layer. Adds a test case for this.

This PR closes #136 