### PR TITLE
Resolve issues #135, #144, #145, #146

### DIFF
--- a/examples/transformer/utils/data_utils.py
+++ b/examples/transformer/utils/data_utils.py
@@ -85,10 +85,6 @@ class Seq2SeqData(tx.data.DataBase[Example, Example]):
             "eos_id": 2,
         }
 
-    def process(self, raw_example: Example) -> Example:  # pylint: disable=no-self-use
-        # No-op. The data should already be processed.
-        return raw_example
-
     def collate(self, examples: List[Example]) -> tx.data.Batch:
         src_seqs = [ex[0] for ex in examples]
         tgt_seqs = [ex[1] for ex in examples]

--- a/texar/torch/data/data/data_base.py
+++ b/texar/torch/data/data/data_base.py
@@ -720,7 +720,7 @@ class DataBase(Dataset, Generic[RawExample, Example], ABC):
                 "__len__ not supported for datasets with undetermined size")
         return self._dataset_size
 
-    def process(self, raw_example: RawExample) -> Example:
+    def process(self, raw_example: RawExample) -> Example:  # pylint: disable=no-self-use
         r"""The process routine. A default implementation of no-op is provided,
         but subclasses are free to override this behavior.
 

--- a/texar/torch/data/data/data_base.py
+++ b/texar/torch/data/data/data_base.py
@@ -721,7 +721,8 @@ class DataBase(Dataset, Generic[RawExample, Example], ABC):
         return self._dataset_size
 
     def process(self, raw_example: RawExample) -> Example:
-        r"""The process routine. Subclasses must implement this method.
+        r"""The process routine. A default implementation of no-op is provided,
+        but subclasses are free to override this behavior.
 
         The process routine would take raw examples loaded from the data source
         as input, and return processed examples. If `parallelize_processing`
@@ -734,7 +735,7 @@ class DataBase(Dataset, Generic[RawExample, Example], ABC):
         Returns:
             The processed example.
         """
-        raise NotImplementedError
+        return raw_example  # type: ignore
 
     def __getitem__(self, index: Union[int, Tuple[int, RawExample]]) -> Example:
         if isinstance(index, int):

--- a/texar/torch/data/data/data_iterators.py
+++ b/texar/torch/data/data/data_iterators.py
@@ -17,6 +17,7 @@ Various data iterator classes.
 
 # pylint: disable=protected-access
 
+import pkg_resources
 from typing import (
     Any, Callable, Dict, Generic, Iterable, Iterator, List, Optional,
     Sequence, Tuple, TypeVar, Union)
@@ -31,7 +32,7 @@ from texar.torch.data.data.dataset_utils import Batch
 from texar.torch.utils.types import MaybeSeq
 from texar.torch.utils.utils import ceildiv
 
-_torch_version = tuple(int(x) for x in _torch_version.split("."))
+_torch_version = pkg_resources.parse_version(_torch_version)
 
 __all__ = [
     "DataIterator",
@@ -347,17 +348,17 @@ class DynamicBatchSampler(torch_sampler.BatchSampler, Generic[Example]):
 
 
 # pylint: disable=ungrouped-imports
-if _torch_version >= (1, 2):  # PyTorch 1.2.0 +
+if _torch_version >= pkg_resources.parse_version("1.2.0"):  # PyTorch 1.2.0 +
     from torch.utils.data._utils.pin_memory import (  # type: ignore
         pin_memory as _pin_memory)
-elif _torch_version >= (1, 1):  # PyTorch 1.1.0 +
+elif _torch_version >= pkg_resources.parse_version("1.1.0"):  # PyTorch 1.1.0 +
     from torch.utils.data._utils.pin_memory import (  # type: ignore
         pin_memory_batch as _pin_memory)
 else:
     from torch.utils.data.dataloader import (  # type: ignore
         pin_memory_batch as _pin_memory)
 
-if _torch_version >= (1, 2):  # PyTorch 1.2.0 +
+if _torch_version >= pkg_resources.parse_version("1.2.0"):  # PyTorch 1.2.0 +
     # PyTorch 1.2 split the `_DataLoaderIter` class into two:
     # `_SingleProcessDataLoaderIter` for when `num_workers == 0`, i.e. when
     # multi-processing is disabled; `_MultiProcessingDataLoaderIter` for

--- a/texar/torch/data/data/data_iterators.py
+++ b/texar/torch/data/data/data_iterators.py
@@ -17,11 +17,11 @@ Various data iterator classes.
 
 # pylint: disable=protected-access
 
-import pkg_resources
 from typing import (
     Any, Callable, Dict, Generic, Iterable, Iterator, List, Optional,
     Sequence, Tuple, TypeVar, Union)
 
+import pkg_resources
 import torch
 from torch import __version__ as _torch_version  # type: ignore
 from torch.utils.data import DataLoader

--- a/texar/torch/data/data/data_iterators_test.py
+++ b/texar/torch/data/data/data_iterators_test.py
@@ -37,9 +37,6 @@ class SamplerTest(unittest.TestCase):
             }
             super().__init__(source, hparams=hparams)
 
-        def process(self, raw_example):
-            return raw_example
-
     def setUp(self) -> None:
         self.size = 10
         self.buffer_size = 5
@@ -256,9 +253,6 @@ class DataIteratorTest(unittest.TestCase):
         class CustomData(DataBase):
             def __init__(self, source):
                 super().__init__(source)
-
-            def process(self, raw_example):
-                return raw_example
 
             def collate(self, examples):
                 return Batch(len(examples), text=examples)

--- a/texar/torch/modules/classifiers/xlnet_classifier.py
+++ b/texar/torch/modules/classifiers/xlnet_classifier.py
@@ -197,6 +197,15 @@ class XLNetClassifier(ClassifierBase):
         :attr:`lr_layer_decay_rate` is not 1.0, parameters from each layer form
         separate groups with different base learning rates.
 
+        The return value of this method can be used in the constructor of
+        optimizers, for example:
+
+        .. code-block:: python
+
+            model = XLNetClassifier(...)
+            param_groups = model.param_groups(lr=2e-5, lr_layer_scale=0.8)
+            optim = torch.optim.Adam(param_groups)
+
         Args:
             lr (float): The learning rate. Can be omitted if
                 :attr:`lr_layer_decay_rate` is 1.0.

--- a/texar/torch/modules/encoders/xlnet_encoder.py
+++ b/texar/torch/modules/encoders/xlnet_encoder.py
@@ -230,6 +230,15 @@ class XLNetEncoder(EncoderBase, PretrainedXLNetMixin):
         :attr:`lr_layer_decay_rate` is not 1.0, parameters from each layer form
         separate groups with different base learning rates.
 
+        The return value of this method can be used in the constructor of
+        optimizers, for example:
+
+        .. code-block:: python
+
+            model = XLNetEncoder(...)
+            param_groups = model.param_groups(lr=2e-5, lr_layer_scale=0.8)
+            optim = torch.optim.Adam(param_groups)
+
         Args:
             lr (float): The learning rate. Can be omitted if
                 :attr:`lr_layer_decay_rate` is 1.0.

--- a/texar/torch/modules/encoders/xlnet_encoder.py
+++ b/texar/torch/modules/encoders/xlnet_encoder.py
@@ -333,8 +333,8 @@ class XLNetEncoder(EncoderBase, PretrainedXLNetMixin):
         Args:
             token_ids: Shape `[batch_size, max_time]`.
             segment_ids: Shape `[batch_size, max_time]`.
-            input_mask: Float tensor of shape `[batch_size, max_time]`. Note that
-                positions with value 1 are masked out.
+            input_mask: Float tensor of shape `[batch_size, max_time]`. Note
+                that positions with value 1 are masked out.
             memory: Memory from previous batches. A list of length `num_layers`,
                 each tensor of shape `[batch_size, mem_len, hidden_dim]`.
             permute_mask: The permutation mask. Float tensor of shape

--- a/texar/torch/modules/encoders/xlnet_encoder.py
+++ b/texar/torch/modules/encoders/xlnet_encoder.py
@@ -331,18 +331,18 @@ class XLNetEncoder(EncoderBase, PretrainedXLNetMixin):
         r"""Compute XLNet representations for the input.
 
         Args:
-            token_ids: Shape `[batch_size, seq_len]`.
-            segment_ids: Shape `[batch_size, seq_len]`.
-            input_mask: Float tensor of shape `[batch_size, seq_len]`. Note that
+            token_ids: Shape `[batch_size, max_time]`.
+            segment_ids: Shape `[batch_size, max_time]`.
+            input_mask: Float tensor of shape `[batch_size, max_time]`. Note that
                 positions with value 1 are masked out.
             memory: Memory from previous batches. A list of length `num_layers`,
                 each tensor of shape `[batch_size, mem_len, hidden_dim]`.
             permute_mask: The permutation mask. Float tensor of shape
-                `[batch_size, seq_len, seq_len]`.
+                `[batch_size, max_time, max_time]`.
                 A value of 0 for ``permute_mask[i, j, k]`` indicates that
                 position `i` attends to position `j` in batch `k`.
             target_mapping: The target token mapping. Float tensor of shape
-                `[batch_size, num_targets, seq_len]`.
+                `[batch_size, num_targets, max_time]`.
                 A value of 1 for ``target_mapping[i, j, k]`` indicates that
                 the `i`-th target token (in order of permutation) in batch `k`
                 is the token at position `j`.
@@ -363,7 +363,7 @@ class XLNetEncoder(EncoderBase, PretrainedXLNetMixin):
         :returns: A tuple of `(output, new_memory)`:
 
             - **`output`**: The final layer output representations. Shape
-              `[batch_size, seq_len, hidden_dim]`.
+              `[batch_size, max_time, hidden_dim]`.
             - **`new_memory`**: The memory of the current batch.
               If `cache_len` is 0, then `new_memory` is `None`. Otherwise, it is
               a list of length `num_layers`, each tensor of shape
@@ -399,10 +399,11 @@ class XLNetEncoder(EncoderBase, PretrainedXLNetMixin):
             -> Tuple[torch.Tensor, Optional[List[torch.Tensor]]]:
         r"""Compute XLNet representations for the input. This layer exists
         because :class:`XLNetDecoder` compute embeddings in the decoder helper.
-        `word_embed` has shape `[batch_size, seq_len, word_embed_dim]`.
+        `word_embed` has shape `[batch_size, max_time, word_embed_dim]`.
         Please refer to :meth:`forward` for the detailed information of other
         arguments.
         """
+        # seq_len == max_time
         # word_embed: [seq_len, batch_size, word_embed_dim]
         word_embed = word_embed.permute(1, 0, 2)
         # segment_ids: [seq_len, batch_size]

--- a/texar/torch/modules/pretrained/pretrained_base.py
+++ b/texar/torch/modules/pretrained/pretrained_base.py
@@ -39,7 +39,7 @@ _default_texar_download_dir: Optional[Path] = None
 def default_download_dir(name: str) -> Path:
     r"""Return the directory to which packages will be downloaded by default.
     """
-    global _default_texar_download_dir
+    global _default_texar_download_dir  # pylint: disable=global-statement
     if _default_texar_download_dir is None:
         if sys.platform == 'win32' and 'APPDATA' in os.environ:
             # On Windows, use %APPDATA%
@@ -70,7 +70,7 @@ def set_default_download_dir(path: Union[str, Path]) -> None:
         raise ValueError(
             f"The specified download directory {path} is not writable")
 
-    global _default_texar_download_dir
+    global _default_texar_download_dir  # pylint: disable=global-statement
     _default_texar_download_dir = path
 
 

--- a/texar/torch/modules/pretrained/pretrained_base.py
+++ b/texar/torch/modules/pretrained/pretrained_base.py
@@ -18,7 +18,7 @@ import os
 import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional, Union
 
 from torch import nn
 
@@ -29,17 +29,18 @@ from texar.torch.utils.types import MaybeList
 
 __all__ = [
     "default_download_dir",
+    "set_default_download_dir",
     "PretrainedMixin",
 ]
+
+_default_texar_download_dir: Optional[Path] = None
 
 
 def default_download_dir(name: str) -> Path:
     r"""Return the directory to which packages will be downloaded by default.
     """
-    package_dir: Path = Path(__file__).parents[4]  # 5 levels up
-    if os.access(package_dir, os.W_OK):
-        texar_download_dir = package_dir / 'texar_download'
-    else:
+    global _default_texar_download_dir
+    if _default_texar_download_dir is None:
         if sys.platform == 'win32' and 'APPDATA' in os.environ:
             # On Windows, use %APPDATA%
             home_dir = Path(os.environ['APPDATA'])
@@ -47,12 +48,30 @@ def default_download_dir(name: str) -> Path:
             # Otherwise, install in the user's home directory.
             home_dir = Path.home()
 
-        texar_download_dir = home_dir / 'texar_download'
+        if os.access(home_dir, os.W_OK):
+            _default_texar_download_dir = home_dir / 'texar_download'
+        else:
+            raise ValueError(f"The path {home_dir} is not writable. Please "
+                             f"manually specify the download directory")
 
-    if not texar_download_dir.exists():
-        texar_download_dir.mkdir(parents=True)
+    if not _default_texar_download_dir.exists():
+        _default_texar_download_dir.mkdir(parents=True)
 
-    return texar_download_dir / name
+    return _default_texar_download_dir / name
+
+
+def set_default_download_dir(path: Union[str, Path]) -> None:
+    if isinstance(path, str):
+        path = Path(path)
+    elif not isinstance(path, Path):
+        raise ValueError("`path` must be a string or a pathlib.Path object")
+
+    if not os.access(path, os.W_OK):
+        raise ValueError(
+            f"The specified download directory {path} is not writable")
+
+    global _default_texar_download_dir
+    _default_texar_download_dir = path
 
 
 class PretrainedMixin(ModuleBase, ABC):

--- a/texar/torch/modules/regressors/xlnet_regressor.py
+++ b/texar/torch/modules/regressors/xlnet_regressor.py
@@ -178,6 +178,15 @@ class XLNetRegressor(RegressorBase):
         :attr:`lr_layer_decay_rate` is not 1.0, parameters from each layer form
         separate groups with different base learning rates.
 
+        The return value of this method can be used in the constructor of
+        optimizers, for example:
+
+        .. code-block:: python
+
+            model = XLNetRegressor(...)
+            param_groups = model.param_groups(lr=2e-5, lr_layer_scale=0.8)
+            optim = torch.optim.Adam(param_groups)
+
         Args:
             lr (float): The learning rate. Can be omitted if
                 :attr:`lr_layer_decay_rate` is 1.0.


### PR DESCRIPTION
This PR resolves various issues:

- #145 Update docstrings for `XLNet*.param_groups()` by adding a code example.
- #144 Change `seq_len` to `max_time` in `XLNetEncoder.forward` docstring.
- #135 Add a default no-op implementation for `DataBase.process()`, and remove no-op implementations in subclasses.
- #146 Move default Texar download directory under home (`~/`), and add a method (`set_default_download_dir`) to allow user-defined default paths.

This PR also adds the following changes:

- Use `pkg_resources` for version parsing, following the approach in Texar-TF. PyTorch versions could also be complex version strings, e.g. `"1.1.0.post2"`.