### PR TITLE
Seperate RoBERTa from BERT

### DIFF
--- a/docs/code/modules.rst
+++ b/docs/code/modules.rst
@@ -64,6 +64,11 @@ Encoders
 .. autoclass:: texar.torch.modules.BERTEncoder
     :members:
 
+:hidden:`RoBERTaEncoder`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.torch.modules.RoBERTaEncoder
+    :members:
+
 :hidden:`GPT2Encoder`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: texar.torch.modules.GPT2Encoder
@@ -219,6 +224,11 @@ Classifiers
 .. autoclass:: texar.torch.modules.BERTClassifier
     :members:
 
+:hidden:`RoBERTaClassifier`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.torch.modules.RoBERTaClassifier
+    :members:
+
 :hidden:`GPT2Classifier`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: texar.torch.modules.GPT2Classifier
@@ -268,6 +278,11 @@ Pre-trained
 :hidden:`PretrainedBERTMixin`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: texar.torch.modules.PretrainedBERTMixin
+    :members:
+
+:hidden:`PretrainedRoBERTaMixin`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.torch.modules.PretrainedRoBERTaMixin
     :members:
 
 :hidden:`PretrainedGPT2Mixin`

--- a/texar/torch/modules/classifiers/__init__.py
+++ b/texar/torch/modules/classifiers/__init__.py
@@ -19,4 +19,5 @@ from texar.torch.modules.classifiers.bert_classifier import *
 from texar.torch.modules.classifiers.classifier_base import *
 from texar.torch.modules.classifiers.conv_classifiers import *
 from texar.torch.modules.classifiers.gpt2_classifier import *
+from texar.torch.modules.classifiers.roberta_classifier import *
 from texar.torch.modules.classifiers.xlnet_classifier import *

--- a/texar/torch/modules/classifiers/bert_classifier.py
+++ b/texar/torch/modules/classifiers/bert_classifier.py
@@ -69,14 +69,14 @@ class BERTClassifier(ClassifierBase, PretrainedBERTMixin):
         super().__init__(hparams=hparams)
 
         # Create the underlying encoder
-        if self.__class__.__name__.startswith('BERT'):
+        if self._MODEL_NAME == 'BERT':
             encoder_hparams = dict_fetch(hparams, BERTEncoder.default_hparams())
 
             self._encoder = BERTEncoder(
                 pretrained_model_name=pretrained_model_name,
                 cache_dir=cache_dir,
                 hparams=encoder_hparams)
-        elif self.__class__.__name__.startswith('RoBERTa'):
+        elif self._MODEL_NAME == 'RoBERTa':
             encoder_hparams = dict_fetch(hparams,
                                          RoBERTaEncoder.default_hparams())
 
@@ -241,11 +241,11 @@ class BERTClassifier(ClassifierBase, PretrainedBERTMixin):
                   ``[batch_size, max_time, num_classes]`` and ``pred`` is of
                   shape ``[batch_size, max_time]``.
         """
-        if self.__class__.__name__.startswith('BERT'):
+        if self._MODEL_NAME == 'BERT':
             enc_outputs, pooled_output = self._encoder(inputs,
                                                        sequence_length,
                                                        segment_ids)
-        elif self.__class__.__name__.startswith('RoBERTa'):
+        elif self._MODEL_NAME == 'RoBERTa':
             enc_outputs, pooled_output = self._encoder(inputs,
                                                        sequence_length)
 

--- a/texar/torch/modules/classifiers/roberta_classifier.py
+++ b/texar/torch/modules/classifiers/roberta_classifier.py
@@ -55,6 +55,7 @@ class RoBERTaClassifier(PretrainedRoBERTaMixin, BERTClassifier):
 
     .. document private functions
     """
+    _ENCODER_CLASS = RoBERTaEncoder
 
     @staticmethod
     def default_hparams():

--- a/texar/torch/modules/encoders/__init__.py
+++ b/texar/torch/modules/encoders/__init__.py
@@ -15,11 +15,12 @@
 Modules of Texar library encoders.
 """
 
-from texar.torch.modules.encoders.bert_encoders import *
+from texar.torch.modules.encoders.bert_encoder import *
 from texar.torch.modules.encoders.conv_encoders import *
 from texar.torch.modules.encoders.encoder_base import *
 from texar.torch.modules.encoders.gpt2_encoder import *
 from texar.torch.modules.encoders.multihead_attention import *
 from texar.torch.modules.encoders.rnn_encoders import *
+from texar.torch.modules.encoders.roberta_encoder import *
 from texar.torch.modules.encoders.transformer_encoder import *
 from texar.torch.modules.encoders.xlnet_encoder import *

--- a/texar/torch/modules/encoders/bert_encoder.py
+++ b/texar/torch/modules/encoders/bert_encoder.py
@@ -71,8 +71,7 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
 
         # Segment embedding for each type of tokens
         self.segment_embedder = None
-        if self._hparams.get('type_vocab_size') and \
-                self._hparams.type_vocab_size > 0:
+        if self._hparams.get('type_vocab_size', 0) > 0:
             self.segment_embedder = WordEmbedder(
                 vocab_size=self._hparams.type_vocab_size,
                 hparams=self._hparams.segment_embed)

--- a/texar/torch/modules/encoders/bert_encoder.py
+++ b/texar/torch/modules/encoders/bert_encoder.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-BERT encoders.
+BERT encoder.
 """
 
 from typing import Optional
@@ -45,8 +45,7 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
         pretrained_model_name (optional): a `str`, the name
             of pre-trained model (e.g., ``bert-base-uncased``). Please refer to
             :class:`~texar.torch.modules.pretrained.PretrainedBERTMixin` for
-            all supported models (including the standard BERT models and
-            variants like RoBERTa).
+            all supported models.
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
@@ -186,7 +185,7 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
             Hyperparameters for word embedding layer.
 
         `"vocab_size"`: int
-            The vocabulary size of `inputs` in `BertModel`.
+            The vocabulary size of `inputs` in BERT model.
 
         `"segment_embed"`: dict
             Hyperparameters for segment embedding layer.

--- a/texar/torch/modules/encoders/bert_encoder.py
+++ b/texar/torch/modules/encoders/bert_encoder.py
@@ -71,7 +71,8 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
 
         # Segment embedding for each type of tokens
         self.segment_embedder = None
-        if self._hparams.type_vocab_size > 0:
+        if self._hparams.get('type_vocab_size') and \
+                self._hparams.type_vocab_size > 0:
             self.segment_embedder = WordEmbedder(
                 vocab_size=self._hparams.type_vocab_size,
                 hparams=self._hparams.segment_embed)

--- a/texar/torch/modules/encoders/bert_encoder_test.py
+++ b/texar/torch/modules/encoders/bert_encoder_test.py
@@ -6,7 +6,7 @@ import unittest
 
 import torch
 
-from texar.torch.modules.encoders.bert_encoders import BERTEncoder
+from texar.torch.modules.encoders.bert_encoder import BERTEncoder
 from texar.torch.utils.test import pretrained_test
 
 

--- a/texar/torch/modules/encoders/roberta_encoder.py
+++ b/texar/torch/modules/encoders/roberta_encoder.py
@@ -1,0 +1,308 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+RoBERTa encoder.
+"""
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+from texar.torch.core import layers
+from texar.torch.modules.embedders.embedders import WordEmbedder
+from texar.torch.modules.embedders.position_embedders import PositionEmbedder
+from texar.torch.modules.encoders.encoder_base import EncoderBase
+from texar.torch.modules.encoders.transformer_encoder import TransformerEncoder
+from texar.torch.modules.pretrained.pretrained_roberta import \
+    PretrainedRoBERTaMixin
+
+__all__ = [
+    "RoBERTaEncoder",
+]
+
+
+class RoBERTaEncoder(EncoderBase, PretrainedRoBERTaMixin):
+    r"""RoBERTa Transformer for encoding sequences.
+
+    This module basically stacks
+    :class:`~texar.torch.modules.embedders.WordEmbedder`,
+    :class:`~texar.torch.modules.embedders.PositionEmbedder`,
+    :class:`~texar.torch.modules.encoders.TransformerEncoder` and a dense
+    pooler.
+
+    Args:
+        pretrained_model_name (optional): a `str`, the name
+            of pre-trained model (e.g., ``roberta-base``). Please refer to
+            :class:`~texar.torch.modules.pretrained.PretrainedRoBERTaMixin` for
+            all supported models.
+            If `None`, the model name in :attr:`hparams` is used.
+        cache_dir (optional): the path to a folder in which the
+            pre-trained models will be cached. If `None` (default),
+            a default directory will be used.
+        hparams (dict or HParams, optional): Hyperparameters. Missing
+            hyperparameter will be set to default values. See
+            :meth:`default_hparams` for the hyperparameter structure
+            and default values.
+    """
+
+    def __init__(self,
+                 pretrained_model_name: Optional[str] = None,
+                 cache_dir: Optional[str] = None,
+                 hparams=None):
+        super().__init__(hparams=hparams)
+
+        self.load_pretrained_config(pretrained_model_name, cache_dir)
+
+        # Word embedding
+        self.word_embedder = WordEmbedder(
+            vocab_size=self._hparams.vocab_size,
+            hparams=self._hparams.embed)
+
+        # Position embedding
+        self.position_embedder = PositionEmbedder(
+            position_size=self._hparams.position_size,
+            hparams=self._hparams.position_embed)
+
+        # The RoBERTa encoder (a TransformerEncoder)
+        self.encoder = TransformerEncoder(hparams=self._hparams.encoder)
+
+        self.pooler = nn.Sequential(
+            nn.Linear(self._hparams.hidden_size, self._hparams.hidden_size),
+            nn.Tanh())
+
+        self.init_pretrained_weights()
+
+    def reset_parameters(self):
+        initialize = layers.get_initializer(self._hparams.initializer)
+        if initialize is not None:
+            # Do not re-initialize LayerNorm modules.
+            for name, param in self.named_parameters():
+                if name.split('.')[-1] == 'weight' and 'layer_norm' not in name:
+                    initialize(param)
+
+    @staticmethod
+    def default_hparams():
+        r"""Returns a dictionary of hyperparameters with default values.
+
+        * The encoder arch is determined by the constructor argument
+          :attr:`pretrained_model_name` if it's specified. In this case,
+          `hparams` are ignored.
+        * Otherwise, the encoder arch is determined by
+          `hparams['pretrained_model_name']` if it's specified. All other
+          configurations in `hparams` are ignored.
+        * If the above two are `None`, the encoder arch is defined by the
+          configurations in `hparams` and weights are randomly initialized.
+
+        .. code-block:: python
+
+            {
+                "pretrained_model_name": "roberta-base",
+                "embed": {
+                    "dim": 768,
+                    "name": "word_embeddings"
+                },
+                "vocab_size": 50265,
+                "position_embed": {
+                    "dim": 768,
+                    "name": "position_embeddings"
+                },
+                "position_size": 514,
+
+                "encoder": {
+                    "dim": 768,
+                    "embedding_dropout": 0.1,
+                    "multihead_attention": {
+                        "dropout_rate": 0.1,
+                        "name": "self",
+                        "num_heads": 12,
+                        "num_units": 768,
+                        "output_dim": 768,
+                        "use_bias": True
+                    },
+                    "name": "encoder",
+                    "num_blocks": 12,
+                    "poswise_feedforward": {
+                        "layers": [
+                            {
+                                "kwargs": {
+                                    "in_features": 768,
+                                    "out_features": 3072,
+                                    "bias": True
+                                },
+                                "type": "Linear"
+                            },
+                            {"type": "BertGELU"},
+                            {
+                                "kwargs": {
+                                    "in_features": 3072,
+                                    "out_features": 768,
+                                    "bias": True
+                                },
+                                "type": "Linear"
+                            }
+                        ]
+                    },
+                    "residual_dropout": 0.1,
+                    "use_bert_config": True
+                    },
+                "hidden_size": 768,
+                "initializer": None,
+                "name": "roberta_encoder",
+            }
+
+        Here:
+
+        The default parameters are values for RoBERTa-Base model.
+
+        `"pretrained_model_name"`: str or None
+            The name of the pre-trained RoBERTa model. If None, the model
+            will be randomly initialized.
+
+        `"embed"`: dict
+            Hyperparameters for word embedding layer.
+
+        `"vocab_size"`: int
+            The vocabulary size of `inputs` in RoBERTa model.
+
+        `"position_embed"`: dict
+            Hyperparameters for position embedding layer.
+
+        `"position_size"`: int
+            The maximum sequence length that this model might ever be used with.
+
+        `"encoder"`: dict
+            Hyperparameters for the TransformerEncoder.
+            See :func:`~texar.torch.modules.TransformerEncoder.default_harams`
+            for details.
+
+        `"hidden_size"`: int
+            Size of the pooler dense layer.
+
+        `"initializer"`: dict, optional
+            Hyperparameters of the default initializer that initializes
+            variables created in this module.
+            See :func:`~texar.torch.core.get_initializer` for details.
+
+        `"name"`: str
+            Name of the module.
+        """
+
+        return {
+            'pretrained_model_name': 'roberta-base',
+            'embed': {
+                'dim': 768,
+                'name': 'word_embeddings'
+            },
+            'vocab_size': 50265,
+            'position_embed': {
+                'dim': 768,
+                'name': 'position_embeddings'
+            },
+            'position_size': 514,
+
+            'encoder': {
+                'dim': 768,
+                'embedding_dropout': 0.1,
+                'multihead_attention': {
+                    'dropout_rate': 0.1,
+                    'name': 'self',
+                    'num_heads': 12,
+                    'num_units': 768,
+                    'output_dim': 768,
+                    'use_bias': True
+                },
+                'name': 'encoder',
+                'num_blocks': 12,
+                'poswise_feedforward': {
+                    'layers': [
+                        {
+                            'kwargs': {
+                                'in_features': 768,
+                                'out_features': 3072,
+                                'bias': True
+                            },
+                            'type': 'Linear'
+                        },
+                        {"type": "BertGELU"},
+                        {
+                            'kwargs': {
+                                'in_features': 3072,
+                                'out_features': 768,
+                                'bias': True
+                            },
+                            'type': 'Linear'
+                        }
+                    ]
+                },
+                'residual_dropout': 0.1,
+                'use_bert_config': True
+            },
+            'hidden_size': 768,
+            'initializer': None,
+            'name': 'roberta_encoder',
+            '@no_typecheck': ['pretrained_model_name']
+        }
+
+    def forward(self,  # type: ignore
+                inputs: torch.Tensor,
+                sequence_length: Optional[torch.LongTensor] = None):
+        r"""Encodes the inputs.
+
+        Args:
+            inputs: A 2D Tensor of shape `[batch_size, max_time]`,
+                containing the token ids of tokens in the input sequences.
+            sequence_length (optional): A 1D Tensor of shape `[batch_size]`.
+                Input tokens beyond respective sequence lengths are masked
+                out automatically.
+
+        Returns:
+            A pair :attr:`(outputs, pooled_output)`
+
+            - :attr:`outputs`:  A Tensor of shape
+              `[batch_size, max_time, dim]` containing the encoded vectors.
+
+            - :attr:`pooled_output`: A Tensor of size
+              `[batch_size, hidden_size]` which is the output of a pooler
+              pre-trained on top of the hidden state associated to the first
+              character of the input (`CLS`), see RoBERTa's paper.
+        """
+
+        word_embeds = self.word_embedder(inputs)
+        batch_size = inputs.size(0)
+        pos_length = inputs.new_full((batch_size,), inputs.size(1),
+                                     dtype=torch.int64)
+        pos_embeds = self.position_embedder(sequence_length=pos_length)
+
+        inputs_embeds = word_embeds + pos_embeds
+
+        if sequence_length is None:
+            sequence_length = inputs.new_full((batch_size,), inputs.size(1),
+                                              dtype=torch.int64)
+
+        output = self.encoder(inputs_embeds, sequence_length)
+
+        # taking the hidden state corresponding to the first token.
+        first_token_tensor = output[:, 0, :]
+
+        pooled_output = self.pooler(first_token_tensor)
+
+        return output, pooled_output
+
+    @property
+    def output_size(self):
+        r"""The feature size of :meth:`forward` output
+        :attr:`pooled_output`.
+        """
+        return self._hparams.hidden_size

--- a/texar/torch/modules/encoders/roberta_encoder.py
+++ b/texar/torch/modules/encoders/roberta_encoder.py
@@ -218,7 +218,9 @@ class RoBERTaEncoder(PretrainedRoBERTaMixin, BERTEncoder):
     def forward(self,  # type: ignore
                 inputs: torch.Tensor,
                 sequence_length: Optional[torch.LongTensor] = None):
-        r"""Encodes the inputs.
+        r"""Encodes the inputs. Differing from the standard BERT, the RoBERTa
+        model does not use segmentation embedding. As a result, RoBERTa does not
+        require `segment_ids` as an input.
 
         Args:
             inputs: A 2D Tensor of shape `[batch_size, max_time]`,

--- a/texar/torch/modules/encoders/roberta_encoder.py
+++ b/texar/torch/modules/encoders/roberta_encoder.py
@@ -217,7 +217,8 @@ class RoBERTaEncoder(PretrainedRoBERTaMixin, BERTEncoder):
 
     def forward(self,  # type: ignore
                 inputs: torch.Tensor,
-                sequence_length: Optional[torch.LongTensor] = None):
+                sequence_length: Optional[torch.LongTensor] = None,
+                segment_ids: Optional[torch.LongTensor] = None):
         r"""Encodes the inputs. Differing from the standard BERT, the RoBERTa
         model does not use segmentation embedding. As a result, RoBERTa does not
         require `segment_ids` as an input.
@@ -240,6 +241,8 @@ class RoBERTaEncoder(PretrainedRoBERTaMixin, BERTEncoder):
               pre-trained on top of the hidden state associated to the first
               character of the input (`CLS`), see RoBERTa's paper.
         """
+        if segment_ids is not None:
+            raise ValueError("segment_ids should be None in RoBERTaEncoder.")
 
         output, pooled_output = super().forward(inputs=inputs,
                                                 sequence_length=sequence_length,

--- a/texar/torch/modules/encoders/roberta_encoder_test.py
+++ b/texar/torch/modules/encoders/roberta_encoder_test.py
@@ -1,0 +1,174 @@
+"""
+Unit tests for RoBERTa encoders.
+"""
+
+import unittest
+
+import torch
+
+from texar.torch.modules.encoders.roberta_encoder import RoBERTaEncoder
+from texar.torch.utils.test import pretrained_test
+
+
+class RoBERTaEncoderTest(unittest.TestCase):
+    r"""Tests :class:`~texar.torch.modules.RoBERTaEncoder` class.
+    """
+
+    def setUp(self) -> None:
+        self.batch_size = 2
+        self.max_length = 3
+        self.inputs = torch.zeros(
+            self.batch_size, self.max_length, dtype=torch.long)
+
+    @pretrained_test
+    def test_model_loading(self):
+        r"""Tests model loading functionality."""
+        for pretrained_model_name in RoBERTaEncoder.available_checkpoints():
+            encoder = RoBERTaEncoder(
+                pretrained_model_name=pretrained_model_name)
+            _, _ = encoder(self.inputs)
+
+    @pretrained_test
+    def test_hparams(self):
+        r"""Tests the priority of the encoder arch parameter.
+        """
+        # case 1: set "pretrained_mode_name" by constructor argument
+        hparams = {
+            "pretrained_model_name": "roberta-large",
+        }
+        encoder = RoBERTaEncoder(pretrained_model_name="roberta-base",
+                                 hparams=hparams)
+        self.assertEqual(encoder.hparams.encoder.num_blocks, 12)
+        _, _ = encoder(self.inputs)
+
+        # case 2: set "pretrained_mode_name" by hparams
+        hparams = {
+            "pretrained_model_name": "roberta-large",
+            "encoder": {
+                "num_blocks": 6,
+            }
+        }
+        encoder = RoBERTaEncoder(hparams=hparams)
+        self.assertEqual(encoder.hparams.encoder.num_blocks, 24)
+        _, _ = encoder(self.inputs)
+
+        # case 3: set to None in both hparams and constructor argument
+        hparams = {
+            "pretrained_model_name": None,
+            "encoder": {
+                "num_blocks": 6,
+            },
+        }
+        encoder = RoBERTaEncoder(hparams=hparams)
+        self.assertEqual(encoder.hparams.encoder.num_blocks, 6)
+        _, _ = encoder(self.inputs)
+
+        # case 4: using default hparams
+        encoder = RoBERTaEncoder()
+        self.assertEqual(encoder.hparams.encoder.num_blocks, 12)
+        _, _ = encoder(self.inputs)
+
+    @pretrained_test
+    def test_trainable_variables(self):
+        r"""Tests the functionality of automatically collecting trainable
+        variables.
+        """
+        # case 1: bert base
+        encoder = RoBERTaEncoder()
+        self.assertEqual(len(encoder.trainable_variables), 2 + 2 + 12 * 16 + 2)
+        _, _ = encoder(self.inputs)
+
+        # case 2: bert large
+        hparams = {
+            "pretrained_model_name": "roberta-large"
+        }
+        encoder = RoBERTaEncoder(hparams=hparams)
+        self.assertEqual(len(encoder.trainable_variables), 2 + 2 + 24 * 16 + 2)
+        _, _ = encoder(self.inputs)
+
+        # case 3: self-designed bert
+        hparams = {
+            "encoder": {
+                "num_blocks": 6,
+            },
+            "pretrained_model_name": None,
+        }
+        encoder = RoBERTaEncoder(hparams=hparams)
+        self.assertEqual(len(encoder.trainable_variables), 2 + 2 + 6 * 16 + 2)
+        _, _ = encoder(self.inputs)
+
+    def test_encode(self):
+        r"""Tests encoding.
+        """
+        # case 1: bert base
+        hparams = {
+            "pretrained_model_name": None,
+        }
+        encoder = RoBERTaEncoder(hparams=hparams)
+
+        inputs = torch.randint(30521, (self.batch_size, self.max_length))
+        outputs, pooled_output = encoder(inputs)
+
+        outputs_dim = encoder.hparams.encoder.dim
+        self.assertEqual(
+            outputs.shape,
+            torch.Size([self.batch_size, self.max_length, outputs_dim]))
+        self.assertEqual(
+            pooled_output.shape,
+            torch.Size([self.batch_size, encoder.output_size]))
+
+        # case 2: self-designed bert
+        hparams = {
+            'pretrained_model_name': None,
+            'embed': {
+                'dim': 96,
+            },
+            'position_embed': {
+                'dim': 96,
+            },
+
+            'encoder': {
+                'dim': 96,
+                'multihead_attention': {
+                    'num_units': 96,
+                    'output_dim': 96,
+                },
+                'poswise_feedforward': {
+                    'layers': [
+                        {
+                            'kwargs': {
+                                'in_features': 96,
+                                'out_features': 96 * 4,
+                                'bias': True,
+                            },
+                            'type': 'Linear',
+                        },
+                        {"type": "BertGELU"},
+                        {
+                            'kwargs': {
+                                'in_features': 96 * 4,
+                                'out_features': 96,
+                                'bias': True,
+                            },
+                            'type': 'Linear',
+                        }
+                    ]
+                },
+            },
+            'hidden_size': 96,
+        }
+        encoder = RoBERTaEncoder(hparams=hparams)
+
+        outputs, pooled_output = encoder(inputs)
+
+        outputs_dim = encoder.hparams.encoder.dim
+        self.assertEqual(
+            outputs.shape,
+            torch.Size([self.batch_size, self.max_length, outputs_dim]))
+        self.assertEqual(
+            pooled_output.shape,
+            torch.Size([self.batch_size, encoder.output_size]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/texar/torch/modules/pretrained/__init__.py
+++ b/texar/torch/modules/pretrained/__init__.py
@@ -18,4 +18,5 @@ Pre-trained modules of Texar library.
 from texar.torch.modules.pretrained.pretrained_base import *
 from texar.torch.modules.pretrained.pretrained_bert import *
 from texar.torch.modules.pretrained.pretrained_gpt2 import *
+from texar.torch.modules.pretrained.pretrained_roberta import *
 from texar.torch.modules.pretrained.pretrained_xlnet import *

--- a/texar/torch/modules/pretrained/pretrained_bert.py
+++ b/texar/torch/modules/pretrained/pretrained_bert.py
@@ -29,54 +29,33 @@ __all__ = [
 ]
 
 _BERT_PATH = "https://storage.googleapis.com/bert_models/"
-_ROBERTA_PATH = "https://dl.fbaipublicfiles.com/fairseq/models/"
 
 
 class PretrainedBERTMixin(PretrainedMixin, ABC):
     r"""A mixin class to support loading pre-trained checkpoints for modules
     that implement the BERT model.
 
-    Both standard BERT models and many variants are supported. Usually, you can
-    specify the :attr:`pretrained_model_name` argument to pick which pre-trained
-    BERT model to use. All available categories of pre-trained models
-    (and names) include:
+    The BERT model was proposed in (`Devlin et al`. 2018)
+    `BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding`_
+    . A bidirectional Transformer language model pre-trained on large text
+    corpora. Available model names include:
 
-      * **Standard BERT**: proposed in (`Devlin et al`. 2018)
-        `BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding`_
-        . A bidirectional Transformer language model pre-trained on large text
-        corpora. Available model names include:
-
-        * ``bert-base-uncased``: 12-layer, 768-hidden, 12-heads,
-          110M parameters.
-        * ``bert-large-uncased``: 24-layer, 1024-hidden, 16-heads,
-          340M parameters.
-        * ``bert-base-cased``: 12-layer, 768-hidden, 12-heads , 110M parameters.
-        * ``bert-large-cased``: 24-layer, 1024-hidden, 16-heads,
-          340M parameters.
-        * ``bert-base-multilingual-uncased``: 102 languages, 12-layer,
-          768-hidden, 12-heads, 110M parameters.
-        * ``bert-base-multilingual-cased``: 104 languages, 12-layer, 768-hidden,
-          12-heads, 110M parameters.
-        * ``bert-base-chinese``: Chinese Simplified and Traditional, 12-layer,
-          768-hidden, 12-heads, 110M parameters.
-
-      * **RoBERTa**: proposed in (`Liu et al`. 2019)
-        `RoBERTa: A Robustly Optimized BERT Pretraining Approach`_
-        . As a variant of the standard BERT model, RoBERTa trains for more
-        iterations on more data with a larger batch size as well as other tweaks
-        in pre-training. Differing from the standard BERT, the RoBERTa model
-        does not use segmentation embedding. Available model names include:
-
-        * ``roberta-base``: RoBERTa using the BERT-base architecture,
-          125M parameters.
-        * ``roberta-large``: RoBERTa using the BERT-large architecture,
-          355M parameters.
+      * ``bert-base-uncased``: 12-layer, 768-hidden, 12-heads,
+        110M parameters.
+      * ``bert-large-uncased``: 24-layer, 1024-hidden, 16-heads,
+        340M parameters.
+      * ``bert-base-cased``: 12-layer, 768-hidden, 12-heads , 110M parameters.
+      * ``bert-large-cased``: 24-layer, 1024-hidden, 16-heads,
+        340M parameters.
+      * ``bert-base-multilingual-uncased``: 102 languages, 12-layer,
+        768-hidden, 12-heads, 110M parameters.
+      * ``bert-base-multilingual-cased``: 104 languages, 12-layer, 768-hidden,
+        12-heads, 110M parameters.
+      * ``bert-base-chinese``: Chinese Simplified and Traditional, 12-layer,
+        768-hidden, 12-heads, 110M parameters.
 
     .. _`BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding`:
         https://arxiv.org/abs/1810.04805
-
-    .. _`RoBERTa: A Robustly Optimized BERT Pretraining Approach`:
-        https://arxiv.org/abs/1907.11692
     """
 
     _MODEL_NAME = "BERT"
@@ -95,10 +74,6 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
             _BERT_PATH + "2018_11_03/multilingual_L-12_H-768_A-12.zip",
         'bert-base-chinese':
             _BERT_PATH + "2018_11_03/chinese_L-12_H-768_A-12.zip",
-        'roberta-base':
-            _ROBERTA_PATH + "roberta.base.tar.gz",
-        'roberta-large':
-            _ROBERTA_PATH + "roberta.large.tar.gz",
     }
 
     @classmethod
@@ -108,41 +83,22 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
         root, _, files = info[0]
         config_path = None
 
-        if pretrained_model_name.startswith('bert'):
-            for file in files:
-                if file.endswith('config.json'):
-                    config_path = os.path.join(root, file)
-                    with open(config_path) as f:
-                        config_ckpt = json.loads(f.read())
-                        hidden_dim = config_ckpt['hidden_size']
-                        vocab_size = config_ckpt['vocab_size']
-                        type_vocab_size = config_ckpt['type_vocab_size']
-                        position_size = config_ckpt['max_position_embeddings']
-                        embedding_dropout = config_ckpt['hidden_dropout_prob']
-                        num_blocks = config_ckpt['num_hidden_layers']
-                        num_heads = config_ckpt['num_attention_heads']
-                        dropout_rate = config_ckpt[
-                            'attention_probs_dropout_prob']
-                        residual_dropout = config_ckpt['hidden_dropout_prob']
-                        intermediate_size = config_ckpt['intermediate_size']
-                        hidden_act = config_ckpt['hidden_act']
-
-        elif pretrained_model_name.startswith('roberta'):
-            for file in files:
-                if file.endswith('model.pt'):
-                    config_path = os.path.join(root, file)
-                    args = torch.load(config_path, map_location="cpu")['args']
-                    hidden_dim = args.encoder_embed_dim
-                    vocab_size = 50265
-                    type_vocab_size = 0
-                    position_size = args.max_positions + 2
-                    embedding_dropout = args.dropout
-                    num_blocks = args.encoder_layers
-                    num_heads = args.encoder_attention_heads
-                    dropout_rate = args.attention_dropout
-                    residual_dropout = args.dropout
-                    intermediate_size = args.encoder_ffn_embed_dim
-                    hidden_act = args.activation_fn
+        for file in files:
+            if file.endswith('config.json'):
+                config_path = os.path.join(root, file)
+                with open(config_path) as f:
+                    config_ckpt = json.loads(f.read())
+                    hidden_dim = config_ckpt['hidden_size']
+                    vocab_size = config_ckpt['vocab_size']
+                    type_vocab_size = config_ckpt['type_vocab_size']
+                    position_size = config_ckpt['max_position_embeddings']
+                    embedding_dropout = config_ckpt['hidden_dropout_prob']
+                    num_blocks = config_ckpt['num_hidden_layers']
+                    num_heads = config_ckpt['num_attention_heads']
+                    dropout_rate = config_ckpt['attention_probs_dropout_prob']
+                    residual_dropout = config_ckpt['hidden_dropout_prob']
+                    intermediate_size = config_ckpt['intermediate_size']
+                    hidden_act = config_ckpt['hidden_act']
 
         if config_path is None:
             raise ValueError(f"Cannot find the config file in {cache_dir}")
@@ -205,12 +161,6 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
 
     def _init_from_checkpoint(self, pretrained_model_name: str,
                               cache_dir: str, **kwargs):
-        if pretrained_model_name.startswith('bert'):
-            self._init_bert_from_checkpoint(cache_dir)
-        elif pretrained_model_name.startswith('roberta'):
-            self._init_roberta_from_checkpoint(cache_dir)
-
-    def _init_bert_from_checkpoint(self, cache_dir: str):
         try:
             import numpy as np
             import tensorflow as tf
@@ -308,77 +258,3 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
                 else:
                     raise NameError(f"Variable with name '{name}' not found")
                 idx += 1
-
-    def _init_roberta_from_checkpoint(self, cache_dir: str):
-        global_tensor_map = {
-            'decoder.sentence_encoder.embed_tokens.weight':
-                'word_embedder._embedding',
-            'decoder.sentence_encoder.embed_positions.weight':
-                'position_embedder._embedding',
-            'decoder.sentence_encoder.emb_layer_norm.weight':
-                'encoder.input_normalizer.weight',
-            'decoder.sentence_encoder.emb_layer_norm.bias':
-                'encoder.input_normalizer.bias',
-        }
-
-        attention_tensor_map = {
-            'final_layer_norm.weight':
-                'encoder.output_layer_norm.{}.weight',
-            'final_layer_norm.bias':
-                'encoder.output_layer_norm.{}.bias',
-            'fc1.weight':
-                'encoder.poswise_networks.{}._layers.0.weight',
-            'fc1.bias':
-                'encoder.poswise_networks.{}._layers.0.bias',
-            'fc2.weight':
-                'encoder.poswise_networks.{}._layers.2.weight',
-            'fc2.bias':
-                'encoder.poswise_networks.{}._layers.2.bias',
-            'self_attn_layer_norm.weight':
-                'encoder.poswise_layer_norm.{}.weight',
-            'self_attn_layer_norm.bias':
-                'encoder.poswise_layer_norm.{}.bias',
-            'self_attn.out_proj.weight':
-                'encoder.self_attns.{}.O_dense.weight',
-            'self_attn.out_proj.bias':
-                'encoder.self_attns.{}.O_dense.bias',
-            'self_attn.in_proj_weight': [
-                'encoder.self_attns.{}.Q_dense.weight',
-                'encoder.self_attns.{}.K_dense.weight',
-                'encoder.self_attns.{}.V_dense.weight',
-            ],
-            'self_attn.in_proj_bias': [
-                'encoder.self_attns.{}.Q_dense.bias',
-                'encoder.self_attns.{}.K_dense.bias',
-                'encoder.self_attns.{}.V_dense.bias'
-            ],
-        }
-
-        checkpoint_path = os.path.abspath(os.path.join(cache_dir, 'model.pt'))
-        device = next(self.parameters()).device
-        params = torch.load(checkpoint_path, map_location=device)['model']
-
-        for name, tensor in params.items():
-            if name in global_tensor_map:
-                v_name = global_tensor_map[name]
-                pointer = self._name_to_variable(v_name)
-                assert pointer.shape == tensor.shape
-                pointer.data = tensor.data.type(pointer.dtype)
-            elif name.startswith('decoder.sentence_encoder.layers.'):
-                name = name.lstrip('decoder.sentence_encoder.layers.')
-                layer_num, layer_name = name[0], name[2:]
-                if layer_name in attention_tensor_map:
-                    v_names = attention_tensor_map[layer_name]
-                    if isinstance(v_names, str):
-                        pointer = self._name_to_variable(
-                            v_names.format(layer_num))
-                        assert pointer.shape == tensor.shape
-                        pointer.data = tensor.data.type(pointer.dtype)
-                    else:
-                        # Q, K, V in self-attention
-                        tensors = torch.chunk(tensor, chunks=3, dim=0)
-                        for i in range(3):
-                            pointer = self._name_to_variable(
-                                v_names[i].format(layer_num))
-                            assert pointer.shape == tensors[i].shape
-                            pointer.data = tensors[i].data.type(pointer.dtype)

--- a/texar/torch/modules/pretrained/pretrained_roberta.py
+++ b/texar/torch/modules/pretrained/pretrained_roberta.py
@@ -1,0 +1,210 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Utils of RoBERTa Modules.
+"""
+
+import os
+from abc import ABC
+from typing import Any, Dict
+
+import torch
+
+from texar.torch.modules.pretrained.pretrained_base import PretrainedMixin
+
+__all__ = [
+    "PretrainedRoBERTaMixin",
+]
+
+_ROBERTA_PATH = "https://dl.fbaipublicfiles.com/fairseq/models/"
+
+
+class PretrainedRoBERTaMixin(PretrainedMixin, ABC):
+    r"""A mixin class to support loading pre-trained checkpoints for modules
+    that implement the RoBERTa model.
+
+    The RoBERTa model was proposed in (`Liu et al`. 2019)
+    `RoBERTa: A Robustly Optimized BERT Pretraining Approach`_.
+    As a variant of the standard BERT model, RoBERTa trains for more
+    iterations on more data with a larger batch size as well as other tweaks
+    in pre-training. Differing from the standard BERT, the RoBERTa model
+    does not use segmentation embedding. Available model names include:
+
+      * ``roberta-base``: RoBERTa using the BERT-base architecture,
+        125M parameters.
+      * ``roberta-large``: RoBERTa using the BERT-large architecture,
+        355M parameters.
+
+    .. _`RoBERTa: A Robustly Optimized BERT Pretraining Approach`:
+        https://arxiv.org/abs/1907.11692
+    """
+
+    _MODEL_NAME = "RoBERTa"
+    _MODEL2URL = {
+        'roberta-base':
+            _ROBERTA_PATH + "roberta.base.tar.gz",
+        'roberta-large':
+            _ROBERTA_PATH + "roberta.large.tar.gz",
+    }
+
+    @classmethod
+    def _transform_config(cls, pretrained_model_name: str,
+                          cache_dir: str) -> Dict[str, Any]:
+        info = list(os.walk(cache_dir))
+        root, _, files = info[0]
+        config_path = None
+
+        for file in files:
+            if file.endswith('model.pt'):
+                config_path = os.path.join(root, file)
+                args = torch.load(config_path, map_location="cpu")['args']
+                hidden_dim = args.encoder_embed_dim
+                vocab_size = 50265
+                position_size = args.max_positions + 2
+                embedding_dropout = args.dropout
+                num_blocks = args.encoder_layers
+                num_heads = args.encoder_attention_heads
+                dropout_rate = args.attention_dropout
+                residual_dropout = args.dropout
+                intermediate_size = args.encoder_ffn_embed_dim
+                hidden_act = args.activation_fn
+
+        if config_path is None:
+            raise ValueError(f"Cannot find the config file in {cache_dir}")
+
+        configs = {
+            'hidden_size': hidden_dim,
+            'embed': {
+                'name': 'word_embeddings',
+                'dim': hidden_dim
+            },
+            'vocab_size': vocab_size,
+            'position_embed': {
+                'name': 'position_embeddings',
+                'dim': hidden_dim
+            },
+            'position_size': position_size,
+            'encoder': {
+                'name': 'encoder',
+                'embedding_dropout': embedding_dropout,
+                'num_blocks': num_blocks,
+                'multihead_attention': {
+                    'use_bias': True,
+                    'num_units': hidden_dim,
+                    'num_heads': num_heads,
+                    'output_dim': hidden_dim,
+                    'dropout_rate': dropout_rate,
+                    'name': 'self'
+                },
+                'residual_dropout': residual_dropout,
+                'dim': hidden_dim,
+                'use_bert_config': True,
+                'poswise_feedforward': {
+                    "layers": [{
+                        'type': 'Linear',
+                        'kwargs': {
+                            'in_features': hidden_dim,
+                            'out_features': intermediate_size,
+                            'bias': True,
+                        }
+                    }, {
+                        'type': 'Bert' + hidden_act.upper()
+                    }, {
+                        'type': 'Linear',
+                        'kwargs': {
+                            'in_features': intermediate_size,
+                            'out_features': hidden_dim,
+                            'bias': True,
+                        }
+                    }],
+                },
+            }
+        }
+
+        return configs
+
+    def _init_from_checkpoint(self, pretrained_model_name: str,
+                              cache_dir: str, **kwargs):
+        global_tensor_map = {
+            'decoder.sentence_encoder.embed_tokens.weight':
+                'word_embedder._embedding',
+            'decoder.sentence_encoder.embed_positions.weight':
+                'position_embedder._embedding',
+            'decoder.sentence_encoder.emb_layer_norm.weight':
+                'encoder.input_normalizer.weight',
+            'decoder.sentence_encoder.emb_layer_norm.bias':
+                'encoder.input_normalizer.bias',
+        }
+
+        attention_tensor_map = {
+            'final_layer_norm.weight':
+                'encoder.output_layer_norm.{}.weight',
+            'final_layer_norm.bias':
+                'encoder.output_layer_norm.{}.bias',
+            'fc1.weight':
+                'encoder.poswise_networks.{}._layers.0.weight',
+            'fc1.bias':
+                'encoder.poswise_networks.{}._layers.0.bias',
+            'fc2.weight':
+                'encoder.poswise_networks.{}._layers.2.weight',
+            'fc2.bias':
+                'encoder.poswise_networks.{}._layers.2.bias',
+            'self_attn_layer_norm.weight':
+                'encoder.poswise_layer_norm.{}.weight',
+            'self_attn_layer_norm.bias':
+                'encoder.poswise_layer_norm.{}.bias',
+            'self_attn.out_proj.weight':
+                'encoder.self_attns.{}.O_dense.weight',
+            'self_attn.out_proj.bias':
+                'encoder.self_attns.{}.O_dense.bias',
+            'self_attn.in_proj_weight': [
+                'encoder.self_attns.{}.Q_dense.weight',
+                'encoder.self_attns.{}.K_dense.weight',
+                'encoder.self_attns.{}.V_dense.weight',
+            ],
+            'self_attn.in_proj_bias': [
+                'encoder.self_attns.{}.Q_dense.bias',
+                'encoder.self_attns.{}.K_dense.bias',
+                'encoder.self_attns.{}.V_dense.bias'
+            ],
+        }
+
+        checkpoint_path = os.path.abspath(os.path.join(cache_dir, 'model.pt'))
+        device = next(self.parameters()).device
+        params = torch.load(checkpoint_path, map_location=device)['model']
+
+        for name, tensor in params.items():
+            if name in global_tensor_map:
+                v_name = global_tensor_map[name]
+                pointer = self._name_to_variable(v_name)
+                assert pointer.shape == tensor.shape
+                pointer.data = tensor.data.type(pointer.dtype)
+            elif name.startswith('decoder.sentence_encoder.layers.'):
+                name = name.lstrip('decoder.sentence_encoder.layers.')
+                layer_num, layer_name = name[0], name[2:]
+                if layer_name in attention_tensor_map:
+                    v_names = attention_tensor_map[layer_name]
+                    if isinstance(v_names, str):
+                        pointer = self._name_to_variable(
+                            v_names.format(layer_num))
+                        assert pointer.shape == tensor.shape
+                        pointer.data = tensor.data.type(pointer.dtype)
+                    else:
+                        # Q, K, V in self-attention
+                        tensors = torch.chunk(tensor, chunks=3, dim=0)
+                        for i in range(3):
+                            pointer = self._name_to_variable(
+                                v_names[i].format(layer_num))
+                            assert pointer.shape == tensors[i].shape
+                            pointer.data = tensors[i].data.type(pointer.dtype)

--- a/texar/torch/modules/pretrained/pretrained_roberta_test.py
+++ b/texar/torch/modules/pretrained/pretrained_roberta_test.py
@@ -1,33 +1,33 @@
 """
-Unit tests for BERT utils.
+Unit tests for RoBERTa utils.
 """
 
 import os
 import unittest
 
-from texar.torch.modules.pretrained.pretrained_bert import *
+from texar.torch.modules.pretrained.pretrained_roberta import *
 from texar.torch.utils.test import pretrained_test
 
 
-class BERTUtilsTest(unittest.TestCase):
-    r"""Tests BERT utils.
+class RoBERTaUtilsTest(unittest.TestCase):
+    r"""Tests RoBERTa utils.
     """
 
     @pretrained_test
-    def test_load_pretrained_bert_AND_transform_bert_to_texar_config(self):
+    def test_load_pretrained_roberta_AND_transform_roberta_to_texar_config(
+            self):
 
-        pretrained_model_dir = PretrainedBERTMixin.download_checkpoint(
-            pretrained_model_name="bert-base-uncased")
+        pretrained_model_dir = PretrainedRoBERTaMixin.download_checkpoint(
+            pretrained_model_name="roberta-base")
 
         info = list(os.walk(pretrained_model_dir))
         _, _, files = info[0]
-        self.assertIn('bert_model.ckpt.meta', files)
-        self.assertIn('bert_model.ckpt.data-00000-of-00001', files)
-        self.assertIn('bert_model.ckpt.index', files)
-        self.assertIn('bert_config.json', files)
+        self.assertIn('dict.txt', files)
+        self.assertIn('model.pt', files)
+        self.assertIn('NOTE', files)
 
-        model_config = PretrainedBERTMixin._transform_config(
-            pretrained_model_name="bert-base-uncased",
+        model_config = PretrainedRoBERTaMixin._transform_config(
+            pretrained_model_name="roberta-base",
             cache_dir=pretrained_model_dir)
 
         exp_config = {
@@ -36,17 +36,12 @@ class BERTUtilsTest(unittest.TestCase):
                 'name': 'word_embeddings',
                 'dim': 768
             },
-            'vocab_size': 30522,
-            'segment_embed': {
-                'name': 'token_type_embeddings',
-                'dim': 768
-            },
-            'type_vocab_size': 2,
+            'vocab_size': 50265,
             'position_embed': {
                 'name': 'position_embeddings',
                 'dim': 768
             },
-            'position_size': 512,
+            'position_size': 514,
             'encoder': {
                 'name': 'encoder',
                 'embedding_dropout': 0.1,


### PR DESCRIPTION
Since the tokenization procedures of `BERT` and `RoBERTa` are very different (`BERT` applies `wordpiece`, while `RoBERTa` applies `BPE`), we decide to separate `RoBERTa` from `BERT`.

As a result, we have `RoBERTaTokenizer` for `RoBERTa` models and `BERTTokenizer` for `BERT` model.