### PR TITLE
Add basic version of tbX

### DIFF
--- a/texar/torch/run/executor_test.py
+++ b/texar/torch/run/executor_test.py
@@ -1,6 +1,8 @@
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
+import os
 from typing import List, Dict, Tuple
 
 import torch
@@ -74,9 +76,11 @@ class ExecutorTest(unittest.TestCase):
                 ("train", 200), ("valid", 50), ("test1", 50), ("test2", 20)]}
 
         self.checkpoint_dir = tempfile.mkdtemp()
+        self.tbx_logging_dir = tempfile.mkdtemp()
 
     def tearDown(self) -> None:
         shutil.rmtree(self.checkpoint_dir)
+        shutil.rmtree(self.tbx_logging_dir)
 
     def test_train_loop(self):
         executor = Executor(
@@ -108,6 +112,41 @@ class ExecutorTest(unittest.TestCase):
 
         executor.train()
         executor.test()
+
+    def test_tbx_logging(self):
+        executor = Executor(
+            model=self.model,
+            train_data=self.datasets["train"],
+            valid_data=self.datasets["valid"],
+            test_data=[self.datasets["test1"], ("t2", self.datasets["test2"])],
+            test_mode='eval',
+            tbx_logging_dir=self.tbx_logging_dir,
+            tbx_log_every=cond.iteration(1),
+            checkpoint_dir=self.checkpoint_dir,
+            max_to_keep=3,
+            save_every=[cond.time(seconds=10), cond.validation(better=True)],
+            train_metrics=[("loss", metric.RunningAverage(20)),
+                           metric.F1(pred_name="preds"),
+                           metric.Accuracy(pred_name="preds")],
+            optimizer={"type": torch.optim.Adam, "kwargs": {}},
+            stop_training_on=cond.epoch(10),
+            valid_metrics=[metric.F1(pred_name="preds"),
+                           ("loss", metric.Average())],
+            validate_every=[cond.epoch()],
+            test_metrics=[metric.F1(pred_name="preds")],
+            plateau_condition=[
+                cond.consecutive(cond.validation(better=False), 2)],
+            action_on_plateau=[action.early_stop(patience=2),
+                               action.reset_params(),
+                               action.scale_lr(0.8)],
+            log_every=cond.iteration(20),
+            show_live_progress=True,
+        )
+
+        executor.train()
+        path = Path(self.tbx_logging_dir)
+        self.assertTrue(path.exists())
+        self.assertEqual(len(list(os.walk(path))), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a basic version of tbX integration. It introduces the following changes

- The train metrics and validation metrics provided by the user are visualized as scalars on tensorboard.

- User can additionally supply frequency of logging for train metrics through `tbx_log_every` argument in the constructor

- The validation metrics are currently logged after every epoch.