### PR TITLE
Move regex and sentencepiece from extras_require to install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ torch >= 1.0.0
 funcsigs >= 1.0.2
 numpy >= 1.15.4
 mypy_extensions >= 0.4.1
+regex
+sentencepiece

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ torch >= 1.0.0
 funcsigs >= 1.0.2
 numpy >= 1.15.4
 mypy_extensions >= 0.4.1
-regex
-sentencepiece
+regex >= 2018.01.10
+sentencepiece >= 0.1.8

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,11 @@ setuptools.setup(
     platforms='any',
 
     install_requires=[
-        'regex',
+        'regex>=2018.01.10',
         'numpy',
         'requests',
         'funcsigs',
-        'sentencepiece',
+        'sentencepiece>=0.1.8',
         'mypy_extensions',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -31,15 +31,17 @@ setuptools.setup(
     platforms='any',
 
     install_requires=[
+        'regex',
         'numpy',
         'requests',
         'funcsigs',
+        'sentencepiece',
         'mypy_extensions',
     ],
     extras_require={
         'torch': ['torch>=1.0'],
         'examples': [],
-        'extras': ['Pillow>=3.0', 'regex', 'sentencepiece'],
+        'extras': ['Pillow>=3.0'],
     },
     package_data={
         "texar.torch": [


### PR DESCRIPTION
Our `Tokenizer` modules have a dependency on these two packages. `regex` and `sentencepiece` should be moved to `install_requires`. Otherwise, `ModuleNotFoundError` will be triggered (if `regex` and `sentencepiece` are not installed) when they try to `import texar.torch`.