### PR TITLE
SentencePieceTokenizer

### DIFF
--- a/docs/code/data.rst
+++ b/docs/code/data.rst
@@ -7,9 +7,14 @@ Data
 Tokenizer
 ==========
 
-:hidden:`PretrainedTokenizerBase`
+:hidden:`TokenizerBase`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. autoclass:: texar.torch.data.PretrainedTokenizerBase
+.. autoclass:: texar.torch.data.TokenizerBase
+    :members:
+
+:hidden:`SentencePieceTokenizer`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.torch.data.SentencePieceTokenizer
     :members:
 
 :hidden:`BERTTokenizer`

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -63,3 +63,4 @@ regressor
 mixin
 tokenizer
 wordpiece
+unigram

--- a/texar/torch/data/tokenizers/__init__.py
+++ b/texar/torch/data/tokenizers/__init__.py
@@ -20,3 +20,4 @@ from texar.torch.data.tokenizers.pretrained_gpt2_tokenizer import *
 from texar.torch.data.tokenizers.pretrained_roberta_tokenizer import *
 from texar.torch.data.tokenizers.pretrained_tokenizer_base import *
 from texar.torch.data.tokenizers.pretrained_xlnet_tokenizer import *
+from texar.torch.data.tokenizers.sentencepiece_tokenizer import *

--- a/texar/torch/data/tokenizers/__init__.py
+++ b/texar/torch/data/tokenizers/__init__.py
@@ -18,6 +18,6 @@ Tokenizer modules of Texar library.
 from texar.torch.data.tokenizers.pretrained_bert_tokenizer import *
 from texar.torch.data.tokenizers.pretrained_gpt2_tokenizer import *
 from texar.torch.data.tokenizers.pretrained_roberta_tokenizer import *
-from texar.torch.data.tokenizers.pretrained_tokenizer_base import *
+from texar.torch.data.tokenizers.tokenizer_base import *
 from texar.torch.data.tokenizers.pretrained_xlnet_tokenizer import *
 from texar.torch.data.tokenizers.sentencepiece_tokenizer import *

--- a/texar/torch/data/tokenizers/pretrained_bert_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_bert_tokenizer.py
@@ -44,7 +44,7 @@ class BERTTokenizer(PretrainedBERTMixin, TokenizerBase):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (`texar_pytorch` folder under user's home
+            a default directory (``texar_pytorch`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/data/tokenizers/pretrained_bert_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_bert_tokenizer.py
@@ -44,7 +44,7 @@ class BERTTokenizer(PretrainedBERTMixin, TokenizerBase):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/data/tokenizers/pretrained_bert_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_bert_tokenizer.py
@@ -23,8 +23,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import os
 
 from texar.torch.modules.pretrained.pretrained_bert import PretrainedBERTMixin
-from texar.torch.data.tokenizers.pretrained_tokenizer_base import \
-    PretrainedTokenizerBase
+from texar.torch.data.tokenizers.tokenizer_base import TokenizerBase
 from texar.torch.data.tokenizers.pretrained_bert_tokenizer_utils import \
     load_vocab, BasicTokenizer, WordpieceTokenizer
 from texar.torch.utils.utils import truncate_seq_pair
@@ -34,7 +33,7 @@ __all__ = [
 ]
 
 
-class BERTTokenizer(PretrainedBERTMixin, PretrainedTokenizerBase):
+class BERTTokenizer(PretrainedBERTMixin, TokenizerBase):
     r"""Pre-trained BERT Tokenizer.
 
     Args:
@@ -45,13 +44,15 @@ class BERTTokenizer(PretrainedBERTMixin, PretrainedTokenizerBase):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (user's home directory) will be used.
+            a default directory (`texar_pytorch` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure
             and default values.
     """
 
+    _IS_PRETRAINED = True
     _MAX_INPUT_SIZE = {
         'bert-base-uncased': 512,
         'bert-large-uncased': 512,
@@ -116,24 +117,24 @@ class BERTTokenizer(PretrainedBERTMixin, PretrainedTokenizerBase):
             split_tokens = self.wordpiece_tokenizer.tokenize(text)
         return split_tokens
 
-    def save_vocab(self, save_directory: str) -> Tuple[str]:
+    def save_vocab(self, save_dir: str) -> Tuple[str]:
         r"""Save the tokenizer vocabulary to a directory or file."""
         index = 0
-        if os.path.isdir(save_directory):
-            save_directory = os.path.join(save_directory,
-                                          self._VOCAB_FILE_NAMES['vocab_file'])
-        with open(save_directory, "w", encoding="utf-8") as writer:
+        if os.path.isdir(save_dir):
+            save_dir = os.path.join(save_dir,
+                                    self._VOCAB_FILE_NAMES['vocab_file'])
+        with open(save_dir, "w", encoding="utf-8") as writer:
             for token, token_index in sorted(self.vocab.items(),
                                              key=lambda kv: kv[1]):
                 if index != token_index:
                     print("Saving vocabulary to {}: vocabulary indices are not "
                           "consecutive. Please check that the vocabulary is "
-                          "not corrupted!".format(save_directory))
+                          "not corrupted!".format(save_dir))
                     index = token_index
                 writer.write(token + u'\n')
                 index += 1
 
-        return (save_directory, )
+        return (save_dir, )
 
     @property
     def vocab_size(self) -> int:

--- a/texar/torch/data/tokenizers/pretrained_gpt2_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_gpt2_tokenizer.py
@@ -25,8 +25,7 @@ import json
 import regex as re
 
 from texar.torch.modules.pretrained.pretrained_gpt2 import PretrainedGPT2Mixin
-from texar.torch.data.tokenizers.pretrained_tokenizer_base import \
-    PretrainedTokenizerBase
+from texar.torch.data.tokenizers.tokenizer_base import TokenizerBase
 from texar.torch.data.tokenizers.pretrained_gpt2_tokenizer_utils import \
     bytes_to_unicode, get_pairs
 
@@ -35,7 +34,7 @@ __all__ = [
 ]
 
 
-class GPT2Tokenizer(PretrainedGPT2Mixin, PretrainedTokenizerBase):
+class GPT2Tokenizer(PretrainedGPT2Mixin, TokenizerBase):
     r"""Pre-trained GPT2 Tokenizer.
 
     Args:
@@ -46,13 +45,15 @@ class GPT2Tokenizer(PretrainedGPT2Mixin, PretrainedTokenizerBase):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (user's home directory) will be used.
+            a default directory (`texar_pytorch` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure
             and default values.
     """
 
+    _IS_PRETRAINED = True
     _MAX_INPUT_SIZE = {
         'gpt2-small': 1024,
         'gpt2-medium': 1024,
@@ -130,15 +131,15 @@ class GPT2Tokenizer(PretrainedGPT2Mixin, PretrainedTokenizerBase):
                 bpe_token for bpe_token in self._bpe(token).split(' '))
         return bpe_tokens
 
-    def save_vocab(self, save_directory: str) -> Tuple[str, str]:
+    def save_vocab(self, save_dir: str) -> Tuple[str, str]:
         r"""Save the tokenizer vocabulary and merge files to a directory."""
-        if not os.path.isdir(save_directory):
+        if not os.path.isdir(save_dir):
             raise ValueError("Vocabulary path ({}) should be a "
-                             "directory".format(save_directory))
+                             "directory".format(save_dir))
 
-        vocab_file = os.path.join(save_directory,
+        vocab_file = os.path.join(save_dir,
                                   self._VOCAB_FILE_NAMES['vocab_file'])
-        merge_file = os.path.join(save_directory,
+        merge_file = os.path.join(save_dir,
                                   self._VOCAB_FILE_NAMES['merges_file'])
 
         with open(vocab_file, 'w', encoding='utf-8') as f:

--- a/texar/torch/data/tokenizers/pretrained_gpt2_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_gpt2_tokenizer.py
@@ -45,7 +45,7 @@ class GPT2Tokenizer(PretrainedGPT2Mixin, TokenizerBase):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/data/tokenizers/pretrained_gpt2_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_gpt2_tokenizer.py
@@ -45,7 +45,7 @@ class GPT2Tokenizer(PretrainedGPT2Mixin, TokenizerBase):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (`texar_pytorch` folder under user's home
+            a default directory (``texar_pytorch`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/data/tokenizers/pretrained_roberta_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_roberta_tokenizer.py
@@ -39,7 +39,7 @@ class RoBERTaTokenizer(GPT2Tokenizer):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (`texar_pytorch` folder under user's home
+            a default directory (``texar_pytorch`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/data/tokenizers/pretrained_roberta_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_roberta_tokenizer.py
@@ -39,7 +39,8 @@ class RoBERTaTokenizer(GPT2Tokenizer):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (user's home directory) will be used.
+            a default directory (`texar_pytorch` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/data/tokenizers/pretrained_roberta_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_roberta_tokenizer.py
@@ -39,7 +39,7 @@ class RoBERTaTokenizer(GPT2Tokenizer):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/data/tokenizers/pretrained_tokenizer_base.py
+++ b/texar/torch/data/tokenizers/pretrained_tokenizer_base.py
@@ -51,6 +51,7 @@ class PretrainedTokenizerBase(PretrainedMixin):
     `sentencepiece` ...).
     """
 
+    _IS_PRETRAINED = True
     _MAX_INPUT_SIZE: Dict[str, Optional[int]]
     _VOCAB_FILE_NAMES: Dict[str, str]
     _SPECIAL_TOKENS_ATTRIBUTES = ["bos_token", "eos_token", "unk_token",
@@ -141,7 +142,11 @@ class PretrainedTokenizerBase(PretrainedMixin):
             raise ValueError("Can't find tokenizer files in {}.".format(
                 saved_directory))
 
-        kwargs: Dict[str, Any] = {'pretrained_model_name': None}
+        kwargs: Dict[str, Any]
+        if cls._IS_PRETRAINED:
+            kwargs = {'pretrained_model_name': None}
+        else:
+            kwargs = {}
 
         added_tokens_file = vocab_files.pop('added_tokens_file', None)
         special_tokens_map_file = vocab_files.pop(

--- a/texar/torch/data/tokenizers/pretrained_xlnet_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_xlnet_tokenizer.py
@@ -53,7 +53,7 @@ class XLNetTokenizer(PretrainedXLNetMixin, TokenizerBase):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/data/tokenizers/pretrained_xlnet_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_xlnet_tokenizer.py
@@ -53,7 +53,7 @@ class XLNetTokenizer(PretrainedXLNetMixin, TokenizerBase):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (`texar_pytorch` folder under user's home
+            a default directory (``texar_pytorch`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/data/tokenizers/pretrained_xlnet_tokenizer.py
+++ b/texar/torch/data/tokenizers/pretrained_xlnet_tokenizer.py
@@ -26,8 +26,7 @@ from shutil import copyfile
 import sentencepiece as spm
 
 from texar.torch.modules.pretrained.pretrained_xlnet import PretrainedXLNetMixin
-from texar.torch.data.tokenizers.pretrained_tokenizer_base import \
-    PretrainedTokenizerBase
+from texar.torch.data.tokenizers.tokenizer_base import TokenizerBase
 from texar.torch.utils.utils import truncate_seq_pair
 
 __all__ = [
@@ -43,7 +42,7 @@ SEG_ID_SEP = 3
 SEG_ID_PAD = 4
 
 
-class XLNetTokenizer(PretrainedXLNetMixin, PretrainedTokenizerBase):
+class XLNetTokenizer(PretrainedXLNetMixin, TokenizerBase):
     r"""Pre-trained XLNet Tokenizer.
 
     Args:
@@ -54,13 +53,15 @@ class XLNetTokenizer(PretrainedXLNetMixin, PretrainedTokenizerBase):
             If None, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (user's home directory) will be used.
+            a default directory (`texar_pytorch` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure
             and default values.
     """
 
+    _IS_PRETRAINED = True
     _MAX_INPUT_SIZE = {
         'xlnet-base-cased': None,
         'xlnet-large-cased': None,
@@ -166,14 +167,14 @@ class XLNetTokenizer(PretrainedXLNetMixin, PretrainedTokenizerBase):
 
         return new_pieces
 
-    def save_vocab(self, save_directory: str) -> Tuple[str]:
+    def save_vocab(self, save_dir: str) -> Tuple[str]:
         r"""Save the sentencepiece vocabulary (copy original file) to
         a directory.
         """
-        if not os.path.isdir(save_directory):
+        if not os.path.isdir(save_dir):
             raise ValueError("Vocabulary path ({}) should be a "
-                             "directory".format(save_directory))
-        out_vocab_file = os.path.join(save_directory,
+                             "directory".format(save_dir))
+        out_vocab_file = os.path.join(save_dir,
                                       self._VOCAB_FILE_NAMES['vocab_file'])
 
         if os.path.abspath(self.vocab_file) != os.path.abspath(out_vocab_file):

--- a/texar/torch/data/tokenizers/sentencepiece_tokenizer.py
+++ b/texar/torch/data/tokenizers/sentencepiece_tokenizer.py
@@ -33,7 +33,7 @@ __all__ = [
 
 class SentencePieceTokenizer(TokenizerBase):
     r"""SentencePiece Tokenizer. This class is a wrapper of Google's
-    `SentencePiece` with richer ready-to-use functionalities such as
+    `SentencePiece`_ with richer ready-to-use functionalities such as
     adding tokens and saving/loading.
 
     `SentencePiece` is an unsupervised text tokenizer mainly for Neural
@@ -42,15 +42,20 @@ class SentencePieceTokenizer(TokenizerBase):
     implements sub-word units (e.g., byte-pair-encoding (BPE) and unigram
     language model) with the extension of direct training from raw sentences.
 
+    The supported algorithms in `SentencePiece` are: ``bpe``, ``word``,
+    ``char``, and ``unigram``.
+
     Args:
         cache_dir (optional): the path to a folder in which the
             trained `sentencepiece` model will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure
             and default values.
+
+    .. _`SentencePiece`: https://github.com/google/sentencepiece
     """
 
     _IS_PRETRAINED = False
@@ -123,7 +128,7 @@ class SentencePieceTokenizer(TokenizerBase):
     def train(cls, cmd: str,  # type: ignore
               cache_dir: Optional[str] = None) -> str:
         r"""Trains the tokenizer from the raw text file. This function is
-        a wrapper of ``sentencepiece.SentencePieceTrainer.Train`` function.
+        a wrapper of `sentencepiece.SentencePieceTrainer.Train`_ function.
 
         Example:
             SentencePieceTokenizer.train('--input=test/botchan.txt
@@ -140,6 +145,9 @@ class SentencePieceTokenizer(TokenizerBase):
 
         Returns:
             Path to the cache directory.
+
+        .. _`sentencepiece.SentencePieceTrainer.Train`:
+            https://github.com/google/sentencepiece/blob/master/python/sentencepiece.py
         """
         if cache_dir is None:
             cache_path = str(default_download_dir('SentencePiece'))
@@ -249,12 +257,13 @@ class SentencePieceTokenizer(TokenizerBase):
             Comma separated list of input sentences.
 
         `"vocab_size"`: int or None
-            Vocabulary size. Note that the vocabulary size is predetermined,
-            and it is used in the tokenizer training procedure.
+            Vocabulary size. The user can specify the vocabulary size, and the
+            tokenizer training procedure will train and yield a vocabulary
+            of the specified size.
 
         `"model_type"`: str
             Model algorithm to train the tokenizer. Available algorithms are:
-            ``unigram``, ``bpe``, ``word``, and ``char``.
+            ``bpe``, ``word``, ``char``, and ``unigram``.
 
         `"bos_token"`: str or None
             Beginning of sentence token. Set None to disable ``bos_token``.

--- a/texar/torch/data/tokenizers/sentencepiece_tokenizer.py
+++ b/texar/torch/data/tokenizers/sentencepiece_tokenizer.py
@@ -45,7 +45,7 @@ class SentencePieceTokenizer(TokenizerBase):
     Args:
         cache_dir (optional): the path to a folder in which the
             trained `sentencepiece` model will be cached. If `None` (default),
-            a default directory (`texar_pytorch` folder under user's home
+            a default directory (``texar_pytorch`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/data/tokenizers/sentencepiece_tokenizer.py
+++ b/texar/torch/data/tokenizers/sentencepiece_tokenizer.py
@@ -43,7 +43,7 @@ class SentencePieceTokenizer(TokenizerBase):
     language model) with the extension of direct training from raw sentences.
 
     The supported algorithms in `SentencePiece` are: ``bpe``, ``word``,
-    ``char``, and ``unigram``.
+    ``char``, and ``unigram``, which is specified in :attr:`hparams`.
 
     Args:
         cache_dir (optional): the path to a folder in which the

--- a/texar/torch/data/tokenizers/sentencepiece_tokenizer.py
+++ b/texar/torch/data/tokenizers/sentencepiece_tokenizer.py
@@ -1,0 +1,256 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+SentencePiece Tokenizer.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import os
+from shutil import copyfile, move
+
+import sentencepiece as spm
+
+from texar.torch.data.tokenizers.pretrained_tokenizer_base import \
+    PretrainedTokenizerBase
+from texar.torch.modules.pretrained.pretrained_base import default_download_dir
+from texar.torch.utils.utils_io import maybe_create_dir
+
+__all__ = [
+    "SentencePieceTokenizer"
+]
+
+
+class SentencePieceTokenizer(PretrainedTokenizerBase):
+    r"""SentencePiece Tokenizer.
+
+    Args:
+        cache_dir (optional): the path to a folder in which the
+            trained `sentencepiece` model will be cached. If `None` (default),
+            a default directory (user's home directory) will be used.
+        hparams (dict or HParams, optional): Hyperparameters. Missing
+            hyperparameter will be set to default values. See
+            :meth:`default_hparams` for the hyperparameter structure
+            and default values.
+    """
+    _IS_PRETRAINED = False
+    _VOCAB_FILE_NAMES = {
+        'vocab_file': 'spiece.model',
+    }
+    _TRAIN_ARG_MAP = {
+        'text_file': 'input',
+        'model_type': 'model_type',
+        'vocab_size': 'vocab_size',
+        'bos_token': 'bos_piece',
+        'eos_token': 'eos_piece',
+        'unk_token': 'unk_piece',
+        'pad_token': 'pad_piece',
+    }
+
+    def __init__(self,
+                 cache_dir: Optional[str] = None,
+                 hparams=None):
+        super().__init__(hparams=hparams)
+
+        self.__dict__: Dict
+
+        if self.hparams['vocab_file'] is not None:
+            self.vocab_file = self.hparams['vocab_file']
+            self.sp_model = spm.SentencePieceProcessor()
+            self.sp_model.Load(self.vocab_file)
+
+            bos_id = self.sp_model.bos_id()
+            eos_id = self.sp_model.eos_id()
+            unk_id = self.sp_model.unk_id()
+            pad_id = self.sp_model.pad_id()
+
+            self.bos_token = None
+            if bos_id != -1:
+                self.bos_token = self.sp_model.IdToPiece(bos_id)
+
+            self.eos_token = None
+            if eos_id != -1:
+                self.eos_token = self.sp_model.IdToPiece(eos_id)
+
+            self.unk_token = None
+            if unk_id != -1:
+                self.unk_token = self.sp_model.IdToPiece(unk_id)
+
+            self.pad_token = None
+            if pad_id != -1:
+                self.pad_token = self.sp_model.IdToPiece(pad_id)
+
+        elif self.hparams['text_file'] is not None:
+            cmd = ['--model_prefix=spiece']
+            for arg, val in self.hparams.items():
+                if arg in self._TRAIN_ARG_MAP:
+                    cmd.append('--' + self._TRAIN_ARG_MAP[arg] + '=' + str(val))
+
+            cache_path = self.train(" ".join(cmd), cache_dir)
+            self.vocab_file = os.path.join(
+                cache_path, self._VOCAB_FILE_NAMES['vocab_file'])
+            self.sp_model = spm.SentencePieceProcessor()
+            self.sp_model.Load(self.vocab_file)
+        else:
+            raise ValueError("'vocab_file' and 'text_file' can not be None "
+                             "at the same time.")
+
+    @classmethod
+    def train(cls, cmd: str,  # type: ignore
+              cache_dir: Optional[str] = None) -> str:
+        if cache_dir is None:
+            cache_path = str(default_download_dir('SentencePiece'))
+        else:
+            if not os.path.isdir(cache_dir):
+                raise ValueError(f"Cache directory ({cache_dir}) should be a "
+                                 f"directory.")
+            cache_path = os.path.abspath(cache_dir)
+
+        maybe_create_dir(cache_path)
+
+        spm.SentencePieceTrainer.Train(cmd)
+        cwd = os.getcwd()
+
+        vocab_file = os.path.join(cwd, cls._VOCAB_FILE_NAMES['vocab_file'])
+        out_vocab_file = os.path.join(
+            cache_path, cls._VOCAB_FILE_NAMES['vocab_file'])
+
+        if os.path.abspath(vocab_file) != os.path.abspath(out_vocab_file):
+            move(vocab_file, out_vocab_file)
+
+        # Delete spiece.vocab (We might want to keep it as well)
+        extra_file = vocab_file.rstrip('model') + 'vocab'
+        os.remove(extra_file)
+
+        return cache_path
+
+    # spm.SentencePieceProcessor() is a SwigPyObject object which cannot be
+    # pickled. We need to define __getstate__ here.
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["sp_model"] = None
+        state["vocab_file"] = None
+        return state, self.vocab_file
+
+    # spm.SentencePieceProcessor() is a SwigPyObject object which cannot be
+    # pickled. We need to define __setstate__ here.
+    def __setstate__(self, d):
+        self.__dict__, self.vocab_file = d
+        self.sp_model = spm.SentencePieceProcessor()
+        self.sp_model.Load(self.vocab_file)
+
+    def save_vocab(self, save_directory: str) -> Tuple[str]:
+        r"""Save the sentencepiece vocabulary (copy original file) to
+        a directory.
+        """
+        if not os.path.isdir(save_directory):
+            raise ValueError("Vocabulary path ({}) should be a "
+                             "directory".format(save_directory))
+        out_vocab_file = os.path.join(
+            save_directory, self._VOCAB_FILE_NAMES['vocab_file'])
+
+        if os.path.abspath(self.vocab_file) != os.path.abspath(out_vocab_file):
+            copyfile(self.vocab_file, out_vocab_file)
+
+        return (out_vocab_file,)
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self.sp_model)
+
+    def _map_text_to_token(self, text: str) -> List[str]:  # type: ignore
+        return self.sp_model.EncodeAsPieces(text)
+
+    def _map_token_to_id(self, token: str) -> int:
+        return self.sp_model.PieceToId(token)
+
+    def _map_id_to_token(self, index: int) -> str:
+        token = self.sp_model.IdToPiece(index)
+        return token
+
+    def map_token_to_text(self, tokens: List[str]) -> str:
+        r"""Maps a sequence of tokens (string) in a single string."""
+        out_string = self.sp_model.DecodePieces(tokens)
+        return out_string
+
+    @staticmethod
+    def default_hparams() -> Dict[str, Any]:
+        r"""Returns a dictionary of hyperparameters with default values.
+
+        * The tokenizer is determined by `hparams['vocab_file']` if it's
+          specified. In this case, all other configurations in `hparams`
+          are ignored.
+        * Otherwise, the tokenizer is trained based on `hparams['text_file']`.
+        * `hparams['vocab_file']` and `hparams['text_file']` can not be None
+        at the same time.
+
+        .. code-block:: python
+
+            {
+                "vocab_file": None,
+                "text_file": None,
+                "vocab_size": None,
+                "model_type": "unigram",
+                "bos_token": "<s>",
+                "eos_token": "</s>",
+                "unk_token": "<unk>",
+                "pad_token": "<pad>",
+            }
+
+        Here:
+
+        `"vocab_file"`: str or None
+            The path to a sentencepiece vocabulary file.
+
+        `"text_file"`: str or None
+            Comma separated list of input sentences.
+
+        `"vocab_size"`: int or None
+            Vocabulary size.
+
+        `"model_type"`: str
+            Model algorithm to train the tokenizer. Available algorithms are:
+            ``unigram``, ``bpe``, ``word``, and ``char``.
+
+        `"bos_token"`: str
+            Beginning of sentence token.
+
+        `"eos_token"`: str
+            End of sentence token.
+
+        `"unk_token"`: str
+            Unknown token.
+
+        `"pad_token"`: str
+            Padding token.
+        """
+        return {
+            'vocab_file': None,
+            'text_file': None,
+            'vocab_size': None,
+            'model_type': 'unigram',
+            'bos_token': '<s>',
+            'eos_token': '</s>',
+            'pad_token': '<pad>',
+            'unk_token': '<unk>',
+        }
+
+    @classmethod
+    def _transform_config(cls, pretrained_model_name: str,
+                          cache_dir: str) -> Dict[str, Any]:
+        pass
+
+    def _init_from_checkpoint(self, pretrained_model_name: str,
+                              cache_dir: str, **kwargs):
+        pass

--- a/texar/torch/data/tokenizers/sentencepiece_tokenizer_test.py
+++ b/texar/torch/data/tokenizers/sentencepiece_tokenizer_test.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for SentencePiece tokenizer.
+"""
+
+import unittest
+
+import os
+import pickle
+import tempfile
+
+from texar.torch.data.data_utils import maybe_download
+from texar.torch.data.tokenizers.sentencepiece_tokenizer import \
+    SentencePieceTokenizer
+
+
+class SentencePieceTokenizerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.SAMPLE_VOCAB = maybe_download(
+            'https://github.com/google/sentencepiece/blob/master/'
+            'python/test/test_model.model?raw=true', self.tmp_dir.name)
+
+        self.tokenizer = SentencePieceTokenizer.load(self.SAMPLE_VOCAB)
+
+        self.tokenizer.save(self.tmp_dir.name)
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def test_load(self):
+        tokenizer = SentencePieceTokenizer.load(self.tmp_dir.name)
+
+        self.assertEqual(1000, len(tokenizer))
+        self.assertEqual(0, tokenizer.map_token_to_id('<unk>'))
+        self.assertEqual(1, tokenizer.map_token_to_id('<s>'))
+        self.assertEqual(2, tokenizer.map_token_to_id('</s>'))
+        self.assertEqual('<unk>', tokenizer.map_id_to_token(0))
+        self.assertEqual('<s>', tokenizer.map_id_to_token(1))
+        self.assertEqual('</s>', tokenizer.map_id_to_token(2))
+        for i in range(len(tokenizer)):
+            token = tokenizer.map_id_to_token(i)
+            self.assertEqual(i, tokenizer.map_token_to_id(token))
+
+    def test_roundtrip(self):
+        tokenizer = SentencePieceTokenizer.load(self.tmp_dir.name)
+
+        text = 'I saw a girl with a telescope.'
+        ids = tokenizer.map_text_to_id(text)
+        tokens = tokenizer.map_text_to_token(text)
+
+        self.assertEqual(text, tokenizer.map_id_to_text(ids))
+        self.assertEqual(text, tokenizer.map_token_to_text(tokens))
+
+    def test_train(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        TEXT_FILE = maybe_download(
+            'https://github.com/google/sentencepiece/blob/master/'
+            'data/botchan.txt?raw=true', tmp_dir.name)
+
+        hparams = {
+            "vocab_file": None,
+            "text_file": TEXT_FILE,
+            "vocab_size": 1000,
+        }
+        tokenizer = SentencePieceTokenizer(hparams=hparams)
+
+        with open(TEXT_FILE, 'r', encoding='utf-8') as file:
+            for line in file:
+                tokenizer.map_token_to_text(tokenizer.map_text_to_token(line))
+                tokenizer.map_id_to_text(tokenizer.map_text_to_id(line))
+
+    def test_pickle(self):
+        tokenizer = SentencePieceTokenizer.load(self.tmp_dir.name)
+        self.assertIsNotNone(tokenizer)
+
+        text = u"Munich and Berlin are nice cities"
+        subwords = tokenizer.map_text_to_token(text)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            filename = os.path.join(tmpdirname, u"tokenizer.bin")
+            with open(filename, "wb") as f:
+                pickle.dump(tokenizer, f)
+            with open(filename, "rb") as f:
+                tokenizer_new = pickle.load(f)
+
+        subwords_loaded = tokenizer_new.map_text_to_token(text)
+
+        self.assertListEqual(subwords, subwords_loaded)
+
+    def test_save_load(self):
+        tokenizer = SentencePieceTokenizer.load(self.tmp_dir.name)
+
+        before_tokens = tokenizer.map_text_to_id(
+            u"He is very happy, UNwant\u00E9d,running")
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tokenizer.save(tmpdirname)
+            tokenizer = tokenizer.load(tmpdirname)
+
+        after_tokens = tokenizer.map_text_to_id(
+            u"He is very happy, UNwant\u00E9d,running")
+        self.assertListEqual(before_tokens, after_tokens)
+
+    def test_add_tokens(self):
+        tokenizer = SentencePieceTokenizer.load(self.tmp_dir.name)
+
+        vocab_size = tokenizer.vocab_size
+        all_size = len(tokenizer)
+
+        self.assertNotEqual(vocab_size, 0)
+        self.assertEqual(vocab_size, all_size)
+
+        new_toks = ["aaaaabbbbbb", "cccccccccdddddddd"]
+        added_toks = tokenizer.add_tokens(new_toks)
+        vocab_size_2 = tokenizer.vocab_size
+        all_size_2 = len(tokenizer)
+
+        self.assertNotEqual(vocab_size_2, 0)
+        self.assertEqual(vocab_size, vocab_size_2)
+        self.assertEqual(added_toks, len(new_toks))
+        self.assertEqual(all_size_2, all_size + len(new_toks))
+
+        tokens = tokenizer.map_text_to_id("aaaaabbbbbb low cccccccccdddddddd l")
+        self.assertGreaterEqual(len(tokens), 4)
+        self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
+        self.assertGreater(tokens[-2], tokenizer.vocab_size - 1)
+
+        new_toks_2 = {'eos_token': ">>>>|||<||<<|<<",
+                      'pad_token': "<<<<<|||>|>>>>|>"}
+        added_toks_2 = tokenizer.add_special_tokens(new_toks_2)
+        vocab_size_3 = tokenizer.vocab_size
+        all_size_3 = len(tokenizer)
+
+        self.assertNotEqual(vocab_size_3, 0)
+        self.assertEqual(vocab_size, vocab_size_3)
+        self.assertEqual(added_toks_2, len(new_toks_2))
+        self.assertEqual(all_size_3, all_size_2 + len(new_toks_2))
+
+        tokens = tokenizer.map_text_to_id(
+            ">>>>|||<||<<|<< aaaaabbbbbb low cccccccccdddddddd "
+            "<<<<<|||>|>>>>|> l")
+
+        self.assertGreaterEqual(len(tokens), 6)
+        self.assertGreater(tokens[0], tokenizer.vocab_size - 1)
+        self.assertGreater(tokens[0], tokens[1])
+        self.assertGreater(tokens[-2], tokenizer.vocab_size - 1)
+        self.assertGreater(tokens[-2], tokens[-3])
+        self.assertEqual(tokens[0],
+                         tokenizer.map_token_to_id(tokenizer.eos_token))
+        self.assertEqual(tokens[-2],
+                         tokenizer.map_token_to_id(tokenizer.pad_token))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/texar/torch/data/tokenizers/tokenizer_base.py
+++ b/texar/torch/data/tokenizers/tokenizer_base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Base class for Pre-trained tokenizers.
+Base class for all tokenizers.
 
 The code structure adapted from:
     `https://github.com/huggingface/pytorch-transformers/blob/master/pytorch_transformers/tokenization_utils.py`
@@ -23,11 +23,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import os
 import json
 
-from texar.torch.modules.pretrained.pretrained_base import PretrainedMixin
+from texar.torch.module_base import ModuleBase
 from texar.torch.utils.types import MaybeList
 
 __all__ = [
-    "PretrainedTokenizerBase",
+    "TokenizerBase",
 ]
 
 SPECIAL_TOKENS_MAP_FILE = 'special_tokens_map.json'
@@ -35,8 +35,8 @@ ADDED_TOKENS_FILE = 'added_tokens.json'
 CONFIG_FILE = 'config.json'
 
 
-class PretrainedTokenizerBase(PretrainedMixin):
-    r"""Base class inherited by all pre-trained tokenizer classes. This class
+class TokenizerBase(ModuleBase):
+    r"""Base class inherited by all tokenizer classes. This class
     handles downloading and loading pre-trained tokenizer and adding tokens to
     the vocabulary.
 
@@ -51,7 +51,7 @@ class PretrainedTokenizerBase(PretrainedMixin):
     `sentencepiece` ...).
     """
 
-    _IS_PRETRAINED = True
+    _IS_PRETRAINED: bool
     _MAX_INPUT_SIZE: Dict[str, Optional[int]]
     _VOCAB_FILE_NAMES: Dict[str, str]
     _SPECIAL_TOKENS_ATTRIBUTES = ["bos_token", "eos_token", "unk_token",
@@ -87,8 +87,8 @@ class PretrainedTokenizerBase(PretrainedMixin):
 
     @classmethod
     def load(cls, pretrained_model_path: str, configs: Optional[Dict] = None):
-        r"""Instantiate a pre-trained tokenizer from the pre-trained vocabulary
-        files.
+        r"""Instantiate a tokenizer from the vocabulary files or the saved
+        tokenizer files.
 
         Args:
             pretrained_model_path: The path to a vocabulary file or a folder
@@ -98,7 +98,7 @@ class PretrainedTokenizerBase(PretrainedMixin):
                 by this dictionary.
 
         Returns:
-            A pre-trained tokenizer instance.
+            A tokenizer instance.
         """
         vocab_files = {}
         # Look for the tokenizer main vocabulary files
@@ -187,7 +187,7 @@ class PretrainedTokenizerBase(PretrainedMixin):
 
         return tokenizer
 
-    def save(self, save_directory: str) -> Tuple[str]:
+    def save(self, save_dir: str) -> Tuple[str]:
         r"""Save the tokenizer vocabulary files (with added tokens), tokenizer
         configuration file and a dictionary mapping special token class
         attributes (:attr:`cls_token`, :attr:`unk_token`, ...) to their values
@@ -195,21 +195,21 @@ class PretrainedTokenizerBase(PretrainedMixin):
         using the :meth:`~load`.
 
         Args:
-            save_directory: The path to a folder in which the pre-trained
-                tokenizer files will be saved.
+            save_dir: The path to a folder in which the tokenizer files
+                will be saved.
 
         Return:
             The paths to the vocabulary file, added token file, special token
             mapping file, and the configuration file.
         """
-        if not os.path.isdir(save_directory):
+        if not os.path.isdir(save_dir):
             raise ValueError("Saving directory ({}) should be a "
-                             "directory".format(save_directory))
+                             "directory".format(save_dir))
 
-        special_tokens_map_file = os.path.join(save_directory,
+        special_tokens_map_file = os.path.join(save_dir,
                                                SPECIAL_TOKENS_MAP_FILE)
-        added_tokens_file = os.path.join(save_directory, ADDED_TOKENS_FILE)
-        config_file = os.path.join(save_directory, CONFIG_FILE)
+        added_tokens_file = os.path.join(save_dir, ADDED_TOKENS_FILE)
+        config_file = os.path.join(save_dir, CONFIG_FILE)
 
         with open(special_tokens_map_file, 'w', encoding='utf-8') as f:
             f.write(json.dumps(self.special_tokens_map, ensure_ascii=False))
@@ -229,11 +229,11 @@ class PretrainedTokenizerBase(PretrainedMixin):
                 out_str = u"{}"
             f.write(out_str)
 
-        vocab_files = self.save_vocab(save_directory)
+        vocab_files = self.save_vocab(save_dir)
         return vocab_files + (special_tokens_map_file, added_tokens_file,
                               config_file)
 
-    def save_vocab(self, save_directory):
+    def save_vocab(self, save_dir):
         r"""Save the tokenizer vocabulary to a directory. This method does not
         save added tokens, special token mappings, and the configuration file.
 

--- a/texar/torch/modules/classifiers/bert_classifier.py
+++ b/texar/torch/modules/classifiers/bert_classifier.py
@@ -51,7 +51,8 @@ class BERTClassifier(ClassifierBase, PretrainedBERTMixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameters will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/classifiers/bert_classifier.py
+++ b/texar/torch/modules/classifiers/bert_classifier.py
@@ -51,7 +51,7 @@ class BERTClassifier(ClassifierBase, PretrainedBERTMixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameters will be set to default values. See

--- a/texar/torch/modules/classifiers/gpt2_classifier.py
+++ b/texar/torch/modules/classifiers/gpt2_classifier.py
@@ -51,7 +51,8 @@ class GPT2Classifier(ClassifierBase, PretrainedGPT2Mixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/classifiers/gpt2_classifier.py
+++ b/texar/torch/modules/classifiers/gpt2_classifier.py
@@ -51,7 +51,7 @@ class GPT2Classifier(ClassifierBase, PretrainedGPT2Mixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/modules/classifiers/roberta_classifier.py
+++ b/texar/torch/modules/classifiers/roberta_classifier.py
@@ -47,7 +47,7 @@ class RoBERTaClassifier(PretrainedRoBERTaMixin, BERTClassifier):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameters will be set to default values. See

--- a/texar/torch/modules/classifiers/roberta_classifier.py
+++ b/texar/torch/modules/classifiers/roberta_classifier.py
@@ -47,7 +47,8 @@ class RoBERTaClassifier(PretrainedRoBERTaMixin, BERTClassifier):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameters will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/classifiers/xlnet_classifier.py
+++ b/texar/torch/modules/classifiers/xlnet_classifier.py
@@ -49,7 +49,7 @@ class XLNetClassifier(ClassifierBase, PretrainedXLNetMixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameters will be set to default values. See

--- a/texar/torch/modules/classifiers/xlnet_classifier.py
+++ b/texar/torch/modules/classifiers/xlnet_classifier.py
@@ -49,7 +49,8 @@ class XLNetClassifier(ClassifierBase, PretrainedXLNetMixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameters will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/decoders/gpt2_decoder.py
+++ b/texar/torch/modules/decoders/gpt2_decoder.py
@@ -47,7 +47,8 @@ class GPT2Decoder(TransformerDecoder, PretrainedGPT2Mixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/decoders/gpt2_decoder.py
+++ b/texar/torch/modules/decoders/gpt2_decoder.py
@@ -47,7 +47,7 @@ class GPT2Decoder(TransformerDecoder, PretrainedGPT2Mixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/modules/decoders/xlnet_decoder.py
+++ b/texar/torch/modules/decoders/xlnet_decoder.py
@@ -56,7 +56,7 @@ class XLNetDecoder(XLNetEncoder, DecoderBase[Optional[State], Output]):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/modules/decoders/xlnet_decoder.py
+++ b/texar/torch/modules/decoders/xlnet_decoder.py
@@ -56,7 +56,8 @@ class XLNetDecoder(XLNetEncoder, DecoderBase[Optional[State], Output]):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/encoders/bert_encoder.py
+++ b/texar/torch/modules/encoders/bert_encoder.py
@@ -49,7 +49,8 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/encoders/bert_encoder.py
+++ b/texar/torch/modules/encoders/bert_encoder.py
@@ -49,7 +49,7 @@ class BERTEncoder(EncoderBase, PretrainedBERTMixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/modules/encoders/gpt2_encoder.py
+++ b/texar/torch/modules/encoders/gpt2_encoder.py
@@ -45,7 +45,7 @@ class GPT2Encoder(TransformerEncoder, PretrainedGPT2Mixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/modules/encoders/gpt2_encoder.py
+++ b/texar/torch/modules/encoders/gpt2_encoder.py
@@ -45,7 +45,8 @@ class GPT2Encoder(TransformerEncoder, PretrainedGPT2Mixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/encoders/roberta_encoder.py
+++ b/texar/torch/modules/encoders/roberta_encoder.py
@@ -45,7 +45,8 @@ class RoBERTaEncoder(PretrainedRoBERTaMixin, BERTEncoder):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/encoders/roberta_encoder.py
+++ b/texar/torch/modules/encoders/roberta_encoder.py
@@ -45,7 +45,7 @@ class RoBERTaEncoder(PretrainedRoBERTaMixin, BERTEncoder):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/modules/encoders/xlnet_encoder.py
+++ b/texar/torch/modules/encoders/xlnet_encoder.py
@@ -44,7 +44,7 @@ class XLNetEncoder(EncoderBase, PretrainedXLNetMixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See

--- a/texar/torch/modules/encoders/xlnet_encoder.py
+++ b/texar/torch/modules/encoders/xlnet_encoder.py
@@ -44,7 +44,8 @@ class XLNetEncoder(EncoderBase, PretrainedXLNetMixin):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure

--- a/texar/torch/modules/pretrained/pretrained_base.py
+++ b/texar/torch/modules/pretrained/pretrained_base.py
@@ -49,7 +49,7 @@ def default_download_dir(name: str) -> Path:
             home_dir = Path.home()
 
         if os.access(home_dir, os.W_OK):
-            _default_texar_download_dir = home_dir / 'texar_pytorch'
+            _default_texar_download_dir = home_dir / 'texar_data'
         else:
             raise ValueError(f"The path {home_dir} is not writable. Please "
                              f"manually specify the download directory")

--- a/texar/torch/modules/pretrained/pretrained_base.py
+++ b/texar/torch/modules/pretrained/pretrained_base.py
@@ -49,7 +49,7 @@ def default_download_dir(name: str) -> Path:
             home_dir = Path.home()
 
         if os.access(home_dir, os.W_OK):
-            _default_texar_download_dir = home_dir / 'texar_download'
+            _default_texar_download_dir = home_dir / 'texar_pytorch'
         else:
             raise ValueError(f"The path {home_dir} is not writable. Please "
                              f"manually specify the download directory")

--- a/texar/torch/modules/regressors/xlnet_regressor.py
+++ b/texar/torch/modules/regressors/xlnet_regressor.py
@@ -49,7 +49,7 @@ class XLNetRegressor(RegressorBase):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory (``texar_pytorch`` folder under user's home
+            a default directory (``texar_data`` folder under user's home
             directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameters will be set to default values. See

--- a/texar/torch/modules/regressors/xlnet_regressor.py
+++ b/texar/torch/modules/regressors/xlnet_regressor.py
@@ -49,7 +49,8 @@ class XLNetRegressor(RegressorBase):
             If `None`, the model name in :attr:`hparams` is used.
         cache_dir (optional): the path to a folder in which the
             pre-trained models will be cached. If `None` (default),
-            a default directory will be used.
+            a default directory (``texar_pytorch`` folder under user's home
+            directory) will be used.
         hparams (dict or HParams, optional): Hyperparameters. Missing
             hyperparameters will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure


### PR DESCRIPTION
`SentencePieceTokenizer` is a simple wrapper over `google/sentencepiece`.

You can initiate a `SentencePieceTokenizer` by specifying `vocab_file`:

```python
tokenizer = SentencePieceTokenizer(hparams={"vocab_file": "path to the vocab file"})
```

or directly training from the raw text

```python
tokenizer = SentencePieceTokenizer(hparams={"text_file": "path to the text file"})
```

You can also use `SentencePieceTokenizer.train("cmd")` as a standalone function.

Resolve #176 