### PR TITLE
Add additional datatype support for ScalarData

### DIFF
--- a/examples/sentence_classifier/clas_main.py
+++ b/examples/sentence_classifier/clas_main.py
@@ -58,7 +58,7 @@ class SentenceClassifier(nn.Module):
                 batch: tx.data.Batch) -> Tuple[torch.Tensor, torch.Tensor]:
         logits, pred = self.classifier(
             self.embedder(batch['sentence_text_ids']))
-        loss = F.cross_entropy(logits, batch['label'].long())
+        loss = F.cross_entropy(logits, batch['label'])
         return pred, loss
 
 

--- a/examples/sentence_classifier/config_kim.py
+++ b/examples/sentence_classifier/config_kim.py
@@ -42,7 +42,7 @@ train_data = {
         },
         {
             "files": "./data/sst2.train.labels.txt",
-            "data_type": "int",
+            "data_type": "int64",
             "data_name": "label"
         }
     ]

--- a/texar/torch/core/layers_test.py
+++ b/texar/torch/core/layers_test.py
@@ -51,7 +51,7 @@ class GetLayerTest(unittest.TestCase):
                    }
 
         layer = layers.get_layer(hparams)
-        self.assertTrue(isinstance(layer, nn.Conv1d))
+        self.assertIsInstance(layer, nn.Conv1d)
 
         hparams = {
             "type": "MergeLayer",
@@ -69,7 +69,7 @@ class GetLayerTest(unittest.TestCase):
             }
         }
         layer = layers.get_layer(hparams)
-        self.assertTrue(isinstance(layer, layers.MergeLayer))
+        self.assertIsInstance(layer, layers.MergeLayer)
 
         hparams = {"type": "Conv1d",
                    "kwargs": {"in_channels": 16,
@@ -77,13 +77,13 @@ class GetLayerTest(unittest.TestCase):
                               "kernel_size": 2}
                    }
         layer = layers.get_layer(hparams)
-        self.assertTrue(isinstance(layer, nn.Conv1d))
+        self.assertIsInstance(layer, nn.Conv1d)
 
         hparams = {
             "type": nn.Conv1d(in_channels=16, out_channels=32, kernel_size=2)
         }
         layer = layers.get_layer(hparams)
-        self.assertTrue(isinstance(layer, nn.Conv1d))
+        self.assertIsInstance(layer, nn.Conv1d)
 
 
 class ReducePoolingLayerTest(unittest.TestCase):

--- a/texar/torch/data/data/multi_aligned_data.py
+++ b/texar/torch/data/data/multi_aligned_data.py
@@ -46,7 +46,9 @@ class _DataType(Enum):
     """
     TEXT = "text"
     INT = "int"
+    INT64 = "int64"
     FLOAT = "float"
+    FLOAT64 = "float64"
     RECORD = "record"
 
 
@@ -55,7 +57,8 @@ def _is_text_data(data_type):
 
 
 def _is_scalar_data(data_type):
-    return data_type in [_DataType.INT, _DataType.FLOAT]
+    return data_type in [_DataType.INT, _DataType.INT64, _DataType.FLOAT,
+                         _DataType.FLOAT64]
 
 
 def _is_record_data(data_type):

--- a/texar/torch/data/data/multi_aligned_data.py
+++ b/texar/torch/data/data/multi_aligned_data.py
@@ -33,7 +33,7 @@ from texar.torch.data.embedding import Embedding
 from texar.torch.data.vocabulary import SpecialTokens, Vocab
 from texar.torch.hyperparams import HParams
 from texar.torch.utils import utils, dict_fetch
-from texar.torch.utils.dtypes import is_str
+from texar.torch.utils.dtypes import is_str, get_supported_scalar_types
 
 __all__ = [
     "_default_dataset_hparams",
@@ -41,28 +41,16 @@ __all__ = [
 ]
 
 
-class _DataType(Enum):
-    r"""Enumeration of data types.
-    """
-    TEXT = "text"
-    INT = "int"
-    INT64 = "int64"
-    FLOAT = "float"
-    FLOAT64 = "float64"
-    RECORD = "record"
-
-
 def _is_text_data(data_type):
-    return data_type is _DataType.TEXT
+    return data_type == "text"
 
 
 def _is_scalar_data(data_type):
-    return data_type in [_DataType.INT, _DataType.INT64, _DataType.FLOAT,
-                         _DataType.FLOAT64]
+    return data_type in get_supported_scalar_types()
 
 
 def _is_record_data(data_type):
-    return data_type is _DataType.RECORD
+    return data_type == "record"
 
 
 def _default_dataset_hparams(data_type=None):
@@ -71,13 +59,12 @@ def _default_dataset_hparams(data_type=None):
     See :meth:`texar.torch.data.MultiAlignedData.default_hparams` for details.
     """
     if data_type is None:
-        data_type = _DataType.TEXT
-    else:
-        data_type = _DataType(data_type)
+        data_type = "text"
+
     if _is_text_data(data_type):
         hparams = _default_mono_text_dataset_hparams()
         hparams.update({
-            "data_type": _DataType.TEXT,
+            "data_type": "text",
             "vocab_share_with": None,
             "embedding_init_share_with": None,
             "processing_share_with": None,
@@ -87,7 +74,7 @@ def _default_dataset_hparams(data_type=None):
     elif _is_record_data(data_type):
         hparams = _default_record_dataset_hparams()
         hparams.update({
-            "data_type": _DataType.RECORD,
+            "data_type": "record",
         })
     else:
         raise ValueError(f"Invalid data type {data_type}")
@@ -200,7 +187,7 @@ class MultiAlignedData(
         filters: List[Optional[Callable[[str], bool]]] = []
         self._databases: List[DataBase] = []
         for idx, hparams_i in enumerate(self._hparams.datasets):
-            data_type = _DataType(hparams_i.data_type)
+            data_type = hparams_i.data_type
             source_i: DataSource
 
             if _is_text_data(data_type):

--- a/texar/torch/data/data/multi_aligned_data.py
+++ b/texar/torch/data/data/multi_aligned_data.py
@@ -14,7 +14,6 @@
 """
 Data consisting of multiple aligned parts.
 """
-from enum import Enum
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Union)
 
 import torch

--- a/texar/torch/data/data/multi_aligned_data.py
+++ b/texar/torch/data/data/multi_aligned_data.py
@@ -63,7 +63,7 @@ def _default_dataset_hparams(data_type=None):
     if _is_text_data(data_type):
         hparams = _default_mono_text_dataset_hparams()
         hparams.update({
-            "data_type": "text",
+            "data_type": data_type,
             "vocab_share_with": None,
             "embedding_init_share_with": None,
             "processing_share_with": None,
@@ -73,10 +73,10 @@ def _default_dataset_hparams(data_type=None):
     elif _is_record_data(data_type):
         hparams = _default_record_dataset_hparams()
         hparams.update({
-            "data_type": "record",
+            "data_type": data_type,
         })
     else:
-        raise ValueError(f"Invalid data type {data_type}")
+        raise ValueError(f"Invalid data type '{data_type}'")
     return hparams
 
 

--- a/texar/torch/data/data/multi_aligned_data_test.py
+++ b/texar/torch/data/data/multi_aligned_data_test.py
@@ -154,9 +154,9 @@ class MultiAlignedDataTest(unittest.TestCase):
                     self.assertEqual(i3, 1)
                 self.assertEqual(n1, 128)
                 self.assertEqual(n2, 512)
-                self.assertTrue(isinstance(n1, torch.Tensor))
-                self.assertTrue(isinstance(n2, torch.Tensor))
-                self.assertTrue(isinstance(t4, str))
+                self.assertIsInstance(n1, torch.Tensor)
+                self.assertIsInstance(n2, torch.Tensor)
+                self.assertIsInstance(t4, str)
 
             if discard_index is not None:
                 hpms = text_data._hparams.datasets[discard_index]

--- a/texar/torch/data/data/multi_aligned_data_test.py
+++ b/texar/torch/data/data/multi_aligned_data_test.py
@@ -203,6 +203,29 @@ class MultiAlignedDataTest(unittest.TestCase):
              "length_filter_mode": "truncate"})
         self._run_and_test(hparams, discard_index=0)
 
+    def test_scalar_types(self):
+        """Tests scalar types supported in MultiAlignedData."""
+        # int64 type
+        hparams = copy.copy(self._hparams)
+        hparams["datasets"][3].update({
+            "data_type": "int64"
+        })
+        self._run_and_test(hparams)
+
+        # float type
+        hparams = copy.copy(self._hparams)
+        hparams["datasets"][3].update({
+            "data_type": "float64"
+        })
+        self._run_and_test(hparams)
+
+        # float64 type
+        hparams = copy.copy(self._hparams)
+        hparams["datasets"][3].update({
+            "data_type": "float64"
+        })
+        self._run_and_test(hparams)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/texar/torch/data/data/multi_aligned_data_test.py
+++ b/texar/torch/data/data/multi_aligned_data_test.py
@@ -203,7 +203,7 @@ class MultiAlignedDataTest(unittest.TestCase):
              "length_filter_mode": "truncate"})
         self._run_and_test(hparams, discard_index=0)
 
-    def test_scalar_types(self):
+    def test_supported_scalar_types(self):
         """Tests scalar types supported in MultiAlignedData."""
         # int64 type
         hparams = copy.copy(self._hparams)
@@ -215,7 +215,7 @@ class MultiAlignedDataTest(unittest.TestCase):
         # float type
         hparams = copy.copy(self._hparams)
         hparams["datasets"][3].update({
-            "data_type": "float64"
+            "data_type": "float"
         })
         self._run_and_test(hparams)
 
@@ -225,6 +225,31 @@ class MultiAlignedDataTest(unittest.TestCase):
             "data_type": "float64"
         })
         self._run_and_test(hparams)
+
+        # bool type
+        hparams = copy.copy(self._hparams)
+        hparams["datasets"][3].update({
+            "data_type": "bool"
+        })
+        self._run_and_test(hparams)
+
+    def test_unsupported_scalar_types(self):
+        """Tests if exception is thrown for unsupported types."""
+        hparams = copy.copy(self._hparams)
+        hparams["datasets"][3].update({
+            "data_type": "XYZ"
+        })
+
+        with self.assertRaises(ValueError):
+            self._run_and_test(hparams)
+
+        hparams = copy.copy(self._hparams)
+        hparams["datasets"][3].update({
+            "data_type": "str"
+        })
+
+        with self.assertRaises(ValueError):
+            self._run_and_test(hparams)
 
 
 if __name__ == "__main__":

--- a/texar/torch/data/data/record_data_test.py
+++ b/texar/torch/data/data/record_data_test.py
@@ -138,9 +138,9 @@ class RecordDataTest(unittest.TestCase):
                 dtype = get_numpy_dtype(item)
                 value = data_batch[key][0]
                 if dtype is np.str_:
-                    self.assertTrue(isinstance(value, str))
+                    self.assertIsInstance(value, str)
                 elif dtype is np.bytes_:
-                    self.assertTrue(isinstance(value, bytes))
+                    self.assertIsInstance(value, bytes)
                 else:
                     if isinstance(value, torch.Tensor):
                         value_dtype = get_numpy_dtype(value.dtype)

--- a/texar/torch/data/data/scalar_data.py
+++ b/texar/torch/data/data/scalar_data.py
@@ -96,7 +96,7 @@ class ScalarData(DataBase[List[str], Union[int, float]]):
         # In Pytorch versions < 1.1.0, "torch.uint8" is treated as "bool" type
         # hence we set self.data_type = np.uint8 here
         if data_type == "bool":
-            self._data_type = get_numpy_dtype(torch_bool)
+            self._data_type = get_numpy_dtype(str(torch_bool))
         else:
             self._data_type = get_numpy_dtype(data_type)
 

--- a/texar/torch/data/data/scalar_data.py
+++ b/texar/torch/data/data/scalar_data.py
@@ -149,7 +149,8 @@ class ScalarData(DataBase[List[str], Union[int, float]]):
 
             `"data_type"`: str
                 The scalar type. Types defined in
-                :meth:`~texar.torch.utils.dtypes.get_numpy_dtype` are supported.
+                :meth:`~texar.torch.utils.dtypes.get_supported_scalar_types` are
+                supported.
 
             `"other_transformations"`: list
                 A list of transformation functions or function names/paths to

--- a/texar/torch/data/data/scalar_data.py
+++ b/texar/torch/data/data/scalar_data.py
@@ -24,7 +24,8 @@ from texar.torch.data.data.data_base import DataBase, DataSource
 from texar.torch.data.data.dataset_utils import Batch
 from texar.torch.data.data.text_data_base import TextLineDataSource
 from texar.torch.hyperparams import HParams
-from texar.torch.utils.dtypes import get_numpy_dtype, get_supported_scalar_types
+from texar.torch.utils.dtypes import get_numpy_dtype, \
+    get_supported_scalar_types, torch_bool
 
 
 __all__ = [
@@ -91,7 +92,14 @@ class ScalarData(DataBase[List[str], Union[int, float]]):
         data_type = self._hparams.dataset["data_type"]
         if data_type not in get_supported_scalar_types():
             raise ValueError(f"Unsupported data type '{data_type}'")
-        self._data_type = get_numpy_dtype(data_type)
+
+        # In Pytorch versions < 1.1.0, "torch.uint8" is treated as "bool" type
+        # hence we set self.data_type = np.uint8 here
+        if data_type == "bool":
+            self._data_type = get_numpy_dtype(torch_bool)
+        else:
+            self._data_type = get_numpy_dtype(data_type)
+
         if data_source is None:
             data_source = TextLineDataSource(
                 self._hparams.dataset.files,

--- a/texar/torch/data/data/scalar_data.py
+++ b/texar/torch/data/data/scalar_data.py
@@ -17,6 +17,7 @@ preprocessing operations.
 """
 from typing import (List, Optional, Union)
 
+from distutils.util import strtobool
 import numpy as np
 import torch
 
@@ -172,12 +173,12 @@ class ScalarData(DataBase[List[str], Union[int, float]]):
         })
         return hparams
 
-    def process(self, raw_example: List[str]) -> Union[int, float]:
+    def process(self, raw_example: List[str]) -> Union[bool, int, float]:
         assert len(raw_example) == 1
 
         example_: Union[int, str]
         if self._data_type == np.bool_:
-            example_ = int(raw_example[0])
+            example_ = strtobool(raw_example[0])
 
         else:
             example_ = raw_example[0]
@@ -188,7 +189,7 @@ class ScalarData(DataBase[List[str], Union[int, float]]):
             example = transform(example)
         return example
 
-    def collate(self, examples: List[Union[int, float]]) -> Batch:
+    def collate(self, examples: List[Union[bool, int, float]]) -> Batch:
         # convert the list of strings into appropriate tensors here
         examples_np = np.array(examples, dtype=self._data_type)
         collated_examples = torch.from_numpy(examples_np).to(device=self.device)

--- a/texar/torch/data/data/scalar_data_test.py
+++ b/texar/torch/data/data/scalar_data_test.py
@@ -89,14 +89,12 @@ class ScalarDataTest(unittest.TestCase):
             i += 1
             data_type = hparams["dataset"]["data_type"]
             if data_type == "int":
-                self.assertTrue(isinstance(value, torch.Tensor))
                 self.assertEqual(value.dtype, torch.int32)
             elif data_type == "float":
-                self.assertTrue(isinstance(value, torch.Tensor))
                 self.assertEqual(value.dtype, torch.float32)
             elif data_type == "bool":
-                self.assertTrue(isinstance(value, torch.Tensor))
                 self.assertTrue(value.dtype, torch_bool)
+            self.assertIsInstance(value, torch.Tensor)
 
     def test_default_setting(self):
         """Tests the logic of ScalarData.

--- a/texar/torch/data/data/scalar_data_test.py
+++ b/texar/torch/data/data/scalar_data_test.py
@@ -12,6 +12,7 @@ import numpy as np
 import unittest
 
 from texar.torch.data import DataIterator, ScalarData
+from texar.torch.utils.dtypes import torch_bool
 
 
 class ScalarDataTest(unittest.TestCase):
@@ -95,7 +96,7 @@ class ScalarDataTest(unittest.TestCase):
                 self.assertEqual(value.dtype, torch.float32)
             elif data_type == "bool":
                 self.assertTrue(isinstance(value, torch.Tensor))
-                self.assertTrue(value.dtype, torch.bool)
+                self.assertTrue(value.dtype, torch_bool)
 
     def test_default_setting(self):
         """Tests the logic of ScalarData.

--- a/texar/torch/data/data/scalar_data_test.py
+++ b/texar/torch/data/data/scalar_data_test.py
@@ -49,6 +49,24 @@ class ScalarDataTest(unittest.TestCase):
             }
         }
 
+        bool_data = [0, 1]
+        bool_data = [str(i) for i in bool_data]
+        bool_file = tempfile.NamedTemporaryFile()
+        bool_file.write('\n'.join(bool_data).encode("utf-8"))
+        bool_file.flush()
+        self._bool_file = bool_file
+
+        self._bool_hparams = {
+            "num_epochs": 1,
+            "batch_size": 1,
+            "shuffle": False,
+            "dataset": {
+                "files": self._bool_file.name,
+                "data_type": "bool",
+                "data_name": "feat"
+            }
+        }
+
     def _run_and_test(self, hparams, test_transform=False):
         # Construct database
         scalar_data = ScalarData(hparams)
@@ -68,18 +86,23 @@ class ScalarDataTest(unittest.TestCase):
             else:
                 self.assertEqual(i, value)
             i += 1
-            if hparams["dataset"]["data_type"] == "int":
+            data_type = hparams["dataset"]["data_type"]
+            if data_type == "int":
                 self.assertTrue(isinstance(value, torch.Tensor))
                 self.assertEqual(value.dtype, torch.int32)
-            else:
+            elif data_type == "float":
                 self.assertTrue(isinstance(value, torch.Tensor))
                 self.assertEqual(value.dtype, torch.float32)
+            elif data_type == "bool":
+                self.assertTrue(isinstance(value, torch.Tensor))
+                self.assertTrue(value.dtype, torch.bool)
 
     def test_default_setting(self):
         """Tests the logic of ScalarData.
         """
         self._run_and_test(self._int_hparams)
         self._run_and_test(self._float_hparams)
+        self._run_and_test(self._bool_hparams)
 
     def test_shuffle(self):
         """Tests results of toggling shuffle.
@@ -116,6 +139,25 @@ class ScalarDataTest(unittest.TestCase):
         hparams["dataset"].update(
             {"other_transformations": [lambda x: x * 2]})
         self._run_and_test(hparams, test_transform=True)
+
+    def test_unsupported_scalar_types(self):
+        """Tests exception for unsupported scalar types.
+        """
+        hparams = copy.copy(self._int_hparams)
+        hparams["dataset"].update({
+            "data_type": "XYZ"
+        })
+
+        with self.assertRaises(ValueError):
+            self._run_and_test(hparams)
+
+        hparams = copy.copy(self._int_hparams)
+        hparams["dataset"].update({
+            "data_type": "str"
+        })
+
+        with self.assertRaises(ValueError):
+            self._run_and_test(hparams)
 
 
 if __name__ == "__main__":

--- a/texar/torch/modules/classifiers/conv_classifiers_test.py
+++ b/texar/torch/modules/classifiers/conv_classifiers_test.py
@@ -23,7 +23,7 @@ class Conv1DClassifierTest(unittest.TestCase):
                                       in_features=inputs.shape[2])
 
         self.assertEqual(len(classifier.layers), 5)
-        self.assertTrue(isinstance(classifier.layers[-1], nn.Linear))
+        self.assertIsInstance(classifier.layers[-1], nn.Linear)
         logits, pred = classifier(inputs)
         self.assertEqual(logits.shape, torch.Size([128, 2]))
         self.assertEqual(pred.shape, torch.Size([128]))

--- a/texar/torch/utils/dtypes.py
+++ b/texar/torch/utils/dtypes.py
@@ -96,6 +96,21 @@ def is_str(x):
     return isinstance(x, str)
 
 
+def get_supported_scalar_types():
+    r"""Returns a set of scalar types supported.
+    """
+    return {'float32', 'float', 'tf.float32', 'torch.float', 'torch.float32',
+            float, np.float32, torch.float32, 'float64', 'tf.float64',
+            'torch.float64', np.float64, np.float_, torch.float64, 'float16',
+            'tf.float16', 'torch.float16', np.float16, torch.float16, 'int',
+            'int32', 'tf.int32', 'torch.int', 'torch.int32', int, np.int32,
+            torch.int32, 'int64', 'tf.int64', 'torch.int64', np.int64, np.int_,
+            torch.int64, 'int16', 'tf.int16', 'torch.int16', np.int16,
+            torch.int16, 'int8', 'char', 'tf.int8', 'torch.int8', np.int8,
+            torch.int8, 'uint8', 'tf.uint8', 'torch.uint8', np.uint8,
+            torch.uint8}
+
+
 def maybe_hparams_to_dict(hparams: Optional[Union[HParams, Dict[str, Any]]]) \
         -> Optional[Dict[str, Any]]:
     r"""If :attr:`hparams` is an instance of :class:`~texar.torch.HParams`,

--- a/texar/torch/utils/dtypes.py
+++ b/texar/torch/utils/dtypes.py
@@ -91,8 +91,9 @@ def get_supported_scalar_types():
     r"""Returns a list of scalar types supported.
     """
     types = []
-    for _, value in DTYPE_MAP.items():
-        types.extend(value)
+    for key, value in DTYPE_MAP.items():
+        if key not in {np.str_, np.bytes_}:
+            types.extend(value)
 
     return types
 

--- a/texar/torch/utils/dtypes.py
+++ b/texar/torch/utils/dtypes.py
@@ -35,6 +35,26 @@ __all__ = [
 # is still `torch.uint8`.
 torch_bool = (torch.empty(()) < 0).dtype
 
+DTYPE_MAP = {
+    np.float32: ['float32', 'float', 'tf.float32', 'torch.float',
+                 'torch.float32', float, np.float32, torch.float32],
+    np.float64: ['float64', 'tf.float64', 'torch.float64', np.float64,
+                 np.float_, torch.float64],
+    np.float16: ['float16', 'tf.float16', 'torch.float16', np.float16,
+                 torch.float16],
+    np.int32: ['int', 'int32', 'tf.int32', 'torch.int', 'torch.int32', int,
+               np.int32, torch.int32],
+    np.int64: ['int64', 'tf.int64', 'torch.int64', np.int64, np.int_,
+               torch.int64],
+    np.int16: ['int16', 'tf.int16', 'torch.int16', np.int16, torch.int16],
+    np.int8: ['int8', 'char', 'tf.int8', 'torch.int8', np.int8, torch.int8],
+    np.uint8: ['uint8', 'tf.uint8', 'torch.uint8', np.uint8, torch.uint8],
+    np.bool_: ['bool', 'tf.bool', 'torch.bool', bool, np.bool, np.bool_,
+               torch_bool],
+    np.str_: ['string', 'str', 'tf.string', str, np.str, np.str_],
+    np.bytes_: ['bytes', 'np.bytes', bytes, np.bytes_]
+}
+
 
 def get_numpy_dtype(dtype: Union[str, type]):
     r"""Returns equivalent NumPy dtype.
@@ -46,39 +66,10 @@ def get_numpy_dtype(dtype: Union[str, type]):
     Returns:
         The corresponding NumPy dtype.
     """
-    if dtype in {'float32', 'float', 'tf.float32', 'torch.float',
-                 'torch.float32', float, np.float32, torch.float32}:
-        return np.float32
-    elif dtype in {'float64', 'tf.float64', 'torch.float64',
-                   np.float64, np.float_, torch.float64}:
-        return np.float64
-    elif dtype in {'float16', 'tf.float16', 'torch.float16',
-                   np.float16, torch.float16}:
-        return np.float16
-    elif dtype in {'int', 'int32', 'tf.int32', 'torch.int', 'torch.int32',
-                   int, np.int32, torch.int32}:
-        return np.int32
-    elif dtype in {'int64', 'tf.int64', 'torch.int64',
-                   np.int64, np.int_, torch.int64}:
-        return np.int64
-    elif dtype in {'int16', 'tf.int16', 'torch.int16',
-                   np.int16, torch.int16}:
-        return np.int16
-    elif dtype in {'int8', 'char', 'tf.int8', 'torch.int8',
-                   np.int8, torch.int8}:
-        return np.int8
-    elif dtype in {'uint8', 'tf.uint8', 'torch.uint8',
-                   np.uint8, torch.uint8}:
-        return np.uint8
-    elif dtype in {'bool', 'tf.bool', 'torch.bool',
-                   bool, np.bool, np.bool_, torch_bool}:
-        return np.bool_
-    elif dtype in {'string', 'str', 'tf.string',
-                   str, np.str, np.str_}:
-        return np.str_
-    elif dtype in {'bytes', 'np.bytes',
-                   bytes, np.bytes_}:
-        return np.bytes_
+    for np_dtype, valid_values in DTYPE_MAP.items():
+        if dtype in valid_values:
+            return np_dtype
+
     raise ValueError(
         f"Unsupported conversion from type {dtype!s} to NumPy dtype")
 
@@ -97,18 +88,13 @@ def is_str(x):
 
 
 def get_supported_scalar_types():
-    r"""Returns a set of scalar types supported.
+    r"""Returns a list of scalar types supported.
     """
-    return {'float32', 'float', 'tf.float32', 'torch.float', 'torch.float32',
-            float, np.float32, torch.float32, 'float64', 'tf.float64',
-            'torch.float64', np.float64, np.float_, torch.float64, 'float16',
-            'tf.float16', 'torch.float16', np.float16, torch.float16, 'int',
-            'int32', 'tf.int32', 'torch.int', 'torch.int32', int, np.int32,
-            torch.int32, 'int64', 'tf.int64', 'torch.int64', np.int64, np.int_,
-            torch.int64, 'int16', 'tf.int16', 'torch.int16', np.int16,
-            torch.int16, 'int8', 'char', 'tf.int8', 'torch.int8', np.int8,
-            torch.int8, 'uint8', 'tf.uint8', 'torch.uint8', np.uint8,
-            torch.uint8}
+    types = []
+    for _, value in DTYPE_MAP.items():
+        types.extend(value)
+
+    return types
 
 
 def maybe_hparams_to_dict(hparams: Optional[Union[HParams, Dict[str, Any]]]) \


### PR DESCRIPTION
This PR

- Adds additional datatype support for `ScalarData` in `MultiAlignedData` (We now have `get_supported_scalar_types()` method in `dtypes.py` to get list of supported data types.)

- Adds test cases for additional scalar data types supported.

- Adds negative test cases for unsupported scalar data types.