### PR TITLE
Fix connector docs

### DIFF
--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -116,7 +116,8 @@ def _mlp_transform(inputs: TensorStruct,
             ``[max_time, batch_size, ...]`` (i.e., time-major) can
             be transposed to batch-major using
             :func:`~texar.torch.utils.transpose_batch_time` prior to this
-            function.
+            function. The dimensions ``d1, ..., dn`` will be flattened and
+            transformed by a dense layer.
         output_size: Can be an ``int``, a ``torch.Size``, or a (nested)
             tuple of ``int`` or ``torch.Size``.
         activation_fn: Activation function applied to the output.

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -110,14 +110,9 @@ def _mlp_transform(inputs: TensorStruct,
     the output with specified size.
 
     Args:
-        inputs: A tensor of shape ``[batch_size, d1, ..., dn]``
-            (i.e., batch-major), or a (nested) tuple of such elements.
-            A tensor or a (nested) tuple of tensors with shape
-            ``[max_time, batch_size, ...]`` (i.e., time-major) can
-            be transposed to batch-major using
-            :func:`~texar.torch.utils.transpose_batch_time` prior to this
-            function. The dimensions ``d1, ..., dn`` will be flattened and
-            transformed by a dense layer.
+        inputs: A Tensor of shape `[batch_size, d1, ..., dn]`, or a (nested)
+            tuple of such elements. The dimensions `d1, ..., dn` will be flatten
+            and transformed by a dense layer.
         output_size: Can be an ``int``, a ``torch.Size``, or a (nested)
             tuple of ``int`` or ``torch.Size``.
         activation_fn: Activation function applied to the output.

--- a/texar/torch/modules/connectors/connectors.py
+++ b/texar/torch/modules/connectors/connectors.py
@@ -117,7 +117,7 @@ def _mlp_transform(inputs: TensorStruct,
             tuple of ``int`` or ``torch.Size``.
         activation_fn: Activation function applied to the output.
 
-    Returns:
+    :returns:
         If :attr:`output_size` is an ``int`` or a ``torch.Size``,
         returns a tensor of shape ``[batch_size, *, output_size]``.
         If :attr:`output_size` is a tuple of ``int`` or ``torch.Size``,
@@ -234,7 +234,7 @@ class ConstantConnector(ConnectorBase):
             batch_size: An ``int`` or ``int`` scalar tensor, the
                 batch size.
 
-        Returns:
+        :returns:
             A (structure of) tensor whose structure is the same as
             :attr:`output_size`, with value specified by
             ``value`` or :attr:`hparams`.
@@ -322,7 +322,7 @@ class ForwardConnector(ConnectorBase):
         Args:
             inputs: The input (structure of) tensor to pass forward.
 
-        Returns:
+        :returns:
             A (structure of) tensors that re-packs :attr:`inputs` to have
             the specified structure of :attr:`output_size`.
         """
@@ -423,7 +423,7 @@ class MLPTransformConnector(ConnectorBase):
                 tuple of such Tensors. That is, the first dimension of
                 (each) tensor must be the batch dimension.
 
-        Returns:
+        :returns:
             A tensor or a (nested) tuple of tensors of the same structure of
             :attr:`output_size`.
         """
@@ -562,7 +562,7 @@ class ReparameterizedStochasticConnector(ConnectorBase):
                 sample must match :attr:`output_size`.
 
 
-        Returns:
+        :returns:
             A tuple (:attr:`output`, :attr:`sample`), where
 
             - output: A tensor or a (nested) tuple of Tensors with
@@ -716,7 +716,7 @@ class StochasticConnector(ConnectorBase):
                 distribution samples. If ``False``, the structure/shape of a
                 sample must match :attr:`output_size`.
 
-        Returns:
+        :returns:
             A tuple (:attr:`output`, :attr:`sample`), where
 
             - output: A tensor or a (nested) tuple of Tensors with

--- a/texar/torch/modules/connectors/connectors_test.py
+++ b/texar/torch/modules/connectors/connectors_test.py
@@ -34,7 +34,7 @@ class TestConnectors(unittest.TestCase):
         :class:`~texar.torch.modules.connectors.ConstantConnector`.
         """
 
-        state_size = namedtuple('LSTMStateTuple', ['c', 'h'])(256, 256)
+        state_size = namedtuple('LSTMStateTuple', ['h', 'c'])(256, 256)
         connector_0 = ConstantConnector(state_size)
         decoder_initial_state_0 = connector_0(self._batch_size)
         connector_1 = ConstantConnector(
@@ -110,7 +110,7 @@ class TestConnectors(unittest.TestCase):
         r"""Tests the logic of
         :class:`~texar.torch.modules.connectors.MLPTransformConnector`.
         """
-        state_size = namedtuple('LSTMStateTuple', ['c', 'h'])(256, 256)
+        state_size = namedtuple('LSTMStateTuple', ['h', 'c'])(256, 256)
         connector = MLPTransformConnector(state_size, linear_layer_dim=10)
         output = connector(torch.zeros(5, 10))
         output_1 = output[0]


### PR DESCRIPTION
This PR

- Uses `namedtuple('LSTMStateTuple', ['h', 'c'])(...)` instead of `namedtuple('LSTMStateTuple', ['c', 'h'])(...)` in the docs to avoid confusion (#199 )

- Addresses the comments of https://github.com/asyml/texar-pytorch/pull/162 and updates the docs.