### PR TITLE
Refactor XLNet interface

### DIFF
--- a/texar/torch/modules/decoders/xlnet_decoder.py
+++ b/texar/torch/modules/decoders/xlnet_decoder.py
@@ -15,7 +15,6 @@
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type, Union
 
 import torch
-from torch import nn
 from torch.nn import functional as F
 
 from texar.torch.modules.decoders.decoder_base import DecoderBase
@@ -66,26 +65,12 @@ class XLNetDecoder(XLNetEncoder, DecoderBase[Optional[State], Output]):
             :meth:`default_hparams` for the hyperparameter structure
             and default values.
     """
-
+    _IS_DECODE = True
     # Variables persistent during decoding.
     _state_cache_len: int
     _state_recompute_memory: bool
     # required for recomputing memory
     _state_previous_inputs: List[torch.Tensor]
-
-    def __init__(self,
-                 pretrained_model_name: Optional[str] = None,
-                 cache_dir: Optional[str] = None,
-                 hparams=None):
-
-        super().__init__(pretrained_model_name=pretrained_model_name,
-                         cache_dir=cache_dir,
-                         hparams=hparams,
-                         init=False)
-
-        self.lm_bias = nn.Parameter(torch.zeros(self._hparams.vocab_size))
-
-        self.init_pretrained_weights()
 
     @staticmethod
     def default_hparams() -> Dict[str, Any]:

--- a/texar/torch/modules/encoders/xlnet_encoder.py
+++ b/texar/torch/modules/encoders/xlnet_encoder.py
@@ -50,14 +50,13 @@ class XLNetEncoder(EncoderBase, PretrainedXLNetMixin):
             hyperparameter will be set to default values. See
             :meth:`default_hparams` for the hyperparameter structure
             and default values.
-        init (optional): whether to initialize `XLNetEncoder`.
     """
+    _IS_DECODE = False
 
     def __init__(self,
                  pretrained_model_name: Optional[str] = None,
                  cache_dir: Optional[str] = None,
-                 hparams=None,
-                 init=True):
+                 hparams=None):
         super().__init__(hparams=hparams)
         self.load_pretrained_config(pretrained_model_name, cache_dir)
 
@@ -99,8 +98,10 @@ class XLNetEncoder(EncoderBase, PretrainedXLNetMixin):
         self.mask_emb = nn.Parameter(
             torch.Tensor(1, 1, self._hparams.hidden_dim))
 
-        if init:
-            self.init_pretrained_weights()
+        if self._IS_DECODE:
+            self.lm_bias = nn.Parameter(torch.zeros(self._hparams.vocab_size))
+
+        self.init_pretrained_weights()
 
     @staticmethod
     def default_hparams() -> Dict[str, Any]:


### PR DESCRIPTION
Requested by Zhiting's comments in [PR in texar-tf](https://github.com/asyml/texar/pull/206)

Make the interface of `XLNetEncoder` be consistent with other modules.