### PR TITLE
Fix bug in rnn

### DIFF
--- a/texar/torch/utils/rnn.py
+++ b/texar/torch/utils/rnn.py
@@ -279,7 +279,9 @@ def dynamic_rnn(
 
     if sequence_length is not None:
         if not isinstance(sequence_length, torch.Tensor):
-            sequence_length = torch.tensor(sequence_length, dtype=torch.int32)
+            sequence_length = torch.tensor(sequence_length, 
+                                           dtype=torch.int32,
+                                           device=inputs.device)
 
         if sequence_length.dim() != 1:
             raise ValueError(

--- a/texar/torch/utils/rnn.py
+++ b/texar/torch/utils/rnn.py
@@ -279,7 +279,9 @@ def dynamic_rnn(
 
     if sequence_length is not None:
         if not isinstance(sequence_length, torch.Tensor):
-            sequence_length = torch.tensor(sequence_length, dtype=torch.int32)
+            sequence_length = torch.tensor(sequence_length,
+                                           dtype=torch.int32,
+                                           device=inputs.device)
 
         if sequence_length.dim() != 1:
             raise ValueError(

--- a/texar/torch/utils/rnn.py
+++ b/texar/torch/utils/rnn.py
@@ -279,9 +279,7 @@ def dynamic_rnn(
 
     if sequence_length is not None:
         if not isinstance(sequence_length, torch.Tensor):
-            sequence_length = torch.tensor(sequence_length, 
-                                           dtype=torch.int32,
-                                           device=inputs.device)
+            sequence_length = torch.tensor(sequence_length, dtype=torch.int32)
 
         if sequence_length.dim() != 1:
             raise ValueError(

--- a/texar/torch/utils/rnn.py
+++ b/texar/torch/utils/rnn.py
@@ -166,7 +166,8 @@ def bidirectional_dynamic_rnn(
 
     if sequence_length is None:
         sequence_length = torch.tensor([time_steps] * batch_size,
-                                       dtype=torch.int32)
+                                       dtype=torch.int32,
+                                       device=inputs.device)
 
     # Backward direction
     inputs_reverse = reverse_sequence(inputs=inputs,
@@ -290,7 +291,8 @@ def dynamic_rnn(
                              % sequence_length.shape)
     else:
         sequence_length = torch.tensor([time_steps] * batch_size,
-                                       dtype=torch.int32)
+                                       dtype=torch.int32,
+                                       device=inputs.device)
 
     if initial_state is not None:
         state = initial_state


### PR DESCRIPTION
When using rnn without sequence_length, the new tensor created for sequence_length don't have same device as inputs. It will cause the torch.utils.mask_sequences arguments have different device.