### PR TITLE
Bugfix in VAE example

### DIFF
--- a/examples/vae_text/.gitignore
+++ b/examples/vae_text/.gitignore
@@ -2,3 +2,4 @@
 /data/
 /models/
 /simple-examples.tgz
+/yahoo.zip

--- a/examples/vae_text/README.md
+++ b/examples/vae_text/README.md
@@ -2,12 +2,13 @@
 
 This example builds a VAE for text generation, with an LSTM as encoder and an LSTM or [Transformer](https://arxiv.org/pdf/1706.03762.pdf) as decoder. Training is performed on the official PTB data and Yahoo data, respectively. 
 
-The VAE with LSTM decoder is first decribed in [(Bowman et al., 2015) Generating Sentences from a Continuous Space](https://arxiv.org/pdf/1511.06349.pdf)
+The VAE with LSTM decoder is first described in [(Bowman et al., 2015) Generating Sentences from a Continuous Space](https://arxiv.org/pdf/1511.06349.pdf)
 
-The Yahoo dataset is from [(Yang et al., 2017) Improved Variational Autoencoders for Text Modeling using Dilated Convolutions](https://arxiv.org/pdf/1702.08139.pdf), which is created by sampling 100k documents from the original Yahoo Answer data. The average document length is 78 and the vocab size is 200k. 
+The Yahoo dataset is from [(Yang et al., 2017) Improved Variational Autoencoders for Text Modeling using Dilated Convolutions](https://arxiv.org/pdf/1702.08139.pdf), which is created by sampling 100k documents from the original Yahoo Answer data. The average document length is 78 and the vocabulary size is 200k. 
 
 ## Data
 The datasets can be downloaded by running:
+
 ```shell
 python prepare_data.py --data ptb
 python prepare_data.py --data yahoo
@@ -30,11 +31,12 @@ Here:
 
 ## Generation
 Generating sentences with pre-trained model can be performed with the following command:
+
 ```shell
 python vae_train.py --config config_file --mode predict --model /path/to/model.ckpt --out /path/to/output
 ```
 
-Here `--model` specifies the saved model checkpoint, which is saved in `./models/dataset_name/` at training time. For example, the model path is `./models/ptb/ptb_lstmDecoder.ckpt` when generating with a LSTM decoder trained on PTB dataset. Generated sentences will be written to standard output if `--out` is not specifcied.
+Here `--model` specifies the saved model checkpoint, which is saved in `./models/dataset_name/` at training time. For example, the model path is `./models/ptb/ptb_lstmDecoder.ckpt` when generating with a LSTM decoder trained on PTB dataset. Generated sentences will be written to standard output if `--out` is not specified.
 
 ## Results
 

--- a/examples/vae_text/config_lstm_ptb.py
+++ b/examples/vae_text/config_lstm_ptb.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """VAE config.
 """
 

--- a/examples/vae_text/config_lstm_yahoo.py
+++ b/examples/vae_text/config_lstm_yahoo.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Texar Authors. All Rights Reserved.
+# Copyright 2019 The Texar Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """VAE config.
 """
 

--- a/examples/vae_text/config_trans_ptb.py
+++ b/examples/vae_text/config_trans_ptb.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Config file of VAE with Trasnformer decoder, on PTB data.
+"""Config file of VAE with Transformer decoder, on PTB data.
 """
 
 dataset = 'ptb'

--- a/examples/vae_text/config_trans_yahoo.py
+++ b/examples/vae_text/config_trans_yahoo.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Texar Authors. All Rights Reserved.
+# Copyright 2019 The Texar Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """VAE config.
 """
 

--- a/examples/vae_text/vae_train.py
+++ b/examples/vae_text/vae_train.py
@@ -68,8 +68,7 @@ def kl_divergence(means: Tensor, logvars: Tensor) -> Tensor:
 class VAE(nn.Module):
     _latent_z: Tensor
 
-    def __init__(self,
-                 vocab_size: int, config_model):
+    def __init__(self, vocab_size: int, config_model):
         super().__init__()
         # Model architecture
         self._config = config_model
@@ -88,7 +87,7 @@ class VAE(nn.Module):
         if config_model.decoder_type == "lstm":
             self.lstm_decoder = tx.modules.BasicRNNDecoder(
                 input_size=(self.decoder_w_embedder.dim +
-                            config_model.batch_size),
+                            config_model.latent_dims),
                 vocab_size=vocab_size,
                 token_embedder=self._embed_fn_rnn,
                 hparams={"rnn_cell": config_model.dec_cell_hparams})

--- a/examples/vae_text/vae_train.py
+++ b/examples/vae_text/vae_train.py
@@ -361,6 +361,9 @@ def main() -> None:
             latent_z=latent_z,
             max_decoding_length=100)
 
+        if model._config.decoder_type == "transformer":
+            outputs = outputs[0]
+
         sample_tokens = vocab.map_ids_to_tokens_py(outputs.sample_id.cpu())
 
         if filename is None:

--- a/examples/vae_text/vae_train.py
+++ b/examples/vae_text/vae_train.py
@@ -361,7 +361,7 @@ def main() -> None:
             latent_z=latent_z,
             max_decoding_length=100)
 
-        if model._config.decoder_type == "transformer":
+        if config.decoder_type == "transformer":
             outputs = outputs[0]
 
         sample_tokens = vocab.map_ids_to_tokens_py(outputs.sample_id.cpu())

--- a/texar/torch/custom/__init__.py
+++ b/texar/torch/custom/__init__.py
@@ -1,3 +1,16 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Custom modules in Texar
 """

--- a/texar/torch/custom/activation.py
+++ b/texar/torch/custom/activation.py
@@ -1,3 +1,16 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Custom activation functions used in various methods.
 """

--- a/texar/torch/custom/distributions.py
+++ b/texar/torch/custom/distributions.py
@@ -1,3 +1,16 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from torch.distributions import Normal, Independent
 
 

--- a/texar/torch/custom/initializers.py
+++ b/texar/torch/custom/initializers.py
@@ -1,3 +1,16 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Custom initializers used in various methods.
 """


### PR DESCRIPTION
resolve #251 

One more bug: In `infer_greedy` decoding, the output of `TransformerDecoder` is a tuple `(outputs, sequence_length)`, where `outputs` is an instance of `TransformerDecoderOutput`.