### PR TITLE
Fix a few doc issues

### DIFF
--- a/docs/code/modules.rst
+++ b/docs/code/modules.rst
@@ -107,6 +107,11 @@ Decoders
     Bahdanau
     Gumbel
 
+:hidden:`DecoderBase`
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autoclass:: texar.torch.modules.DecoderBase
+    :members:
+
 :hidden:`RNNDecoderBase`
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: texar.torch.modules.RNNDecoderBase

--- a/examples/gpt-2/gpt2_train_main.py
+++ b/examples/gpt-2/gpt2_train_main.py
@@ -232,11 +232,9 @@ def main() -> None:
 
         # Parse samples and write to file
 
-        eos_token_id = tokenizer.map_token_to_id('<|endoftext|>')
-
         _all_input_text = []
         for i in _all_inputs:
-            if i[0] == eos_token_id:
+            if i[0] == eos_token:
                 # '<|endoftext|>' is used as the BOS token. Delete it here
                 i = i[1:]
             i_text = tokenizer.map_id_to_text(i)

--- a/examples/gpt-2/prepare_data.py
+++ b/examples/gpt-2/prepare_data.py
@@ -35,7 +35,7 @@ parser.add_argument(
     help="The output directory where the pickle files will be generated. "
          "By default it is set to be the same as `--data-dir`.")
 parser.add_argument(
-    "--pretrained-model-name", type=str, default="gpt2-small",
+    '--pretrained-model-name', type=str, default='gpt2-small',
     choices=tx.modules.GPT2Decoder.available_checkpoints(),
     help="Name of the pre-trained checkpoint to load.")
 parser.add_argument(

--- a/texar/torch/modules/decoders/rnn_decoder_base.py
+++ b/texar/torch/modules/decoders/rnn_decoder_base.py
@@ -107,14 +107,15 @@ class RNNDecoderBase(DecoderBase[State, Output]):
         <https://www.tensorflow.org/api_docs/python/tf/contrib/seq2seq/dynamic_decode>`_.
 
         See Also:
-            Arguments of :meth:`create_helper`.
+            Arguments of :meth:`create_helper`, for arguments like
+            :attr:`decoding_strategy`.
 
         Args:
             inputs (optional): Input tensors for teacher forcing decoding.
                 Used when :attr:`decoding_strategy` is set to
                 ``"train_greedy"``, or when `hparams`-configured helper is used.
 
-                The attr:`inputs` is a :tensor:`LongTensor` used as index to
+                The :attr:`inputs` is a :tensor:`LongTensor` used as index to
                 look up embeddings and feed in the decoder. For example, if
                 :attr:`embedder` is an instance of
                 :class:`~texar.torch.modules.WordEmbedder`, then :attr:`inputs`
@@ -143,6 +144,10 @@ class RNNDecoderBase(DecoderBase[State, Output]):
                 that defines the decoding strategy. If given,
                 ``decoding_strategy`` and helper configurations in
                 :attr:`hparams` are ignored.
+
+                :meth:`create_helper` can be used to create some of the common
+                helpers for, e.g., teacher-forcing decoding, greedy decoding,
+                sample decoding, etc.
             infer_mode (optional): If not `None`, overrides mode given by
                 `self.training`.
             **kwargs: Other keyword arguments for constructing helpers

--- a/texar/torch/modules/decoders/transformer_decoders.py
+++ b/texar/torch/modules/decoders/transformer_decoders.py
@@ -447,6 +447,24 @@ class TransformerDecoder(DecoderBase[Cache, TransformerDecoderOutput]):
                 :attr:`hparams` are ignored.
             infer_mode (optional): If not `None`, overrides mode given by
                 :attr:`self.training`.
+            **kwargs (optional, dict): Other keyword arguments. Typically ones
+                such as:
+
+                - **start_tokens**: A :tensor:`LongTensor` of shape
+                  ``[batch_size]``, the start tokens.
+                  Used when :attr:`decoding_strategy` is ``"infer_greedy"`` or
+                  ``"infer_sample"`` or when :attr:`beam_search` is set.
+                  Ignored when :attr:`context` is set.
+
+                  When used with the Texar data module, to get ``batch_size``
+                  samples where ``batch_size`` is changing according to the
+                  data module, this can be set as
+                  ``start_tokens=torch.full_like(batch['length'], bos_token_id)``
+
+                - **end_token**: An integer or 0D :tensor:`LongTensor`, the
+                  token that marks the end of decoding.
+                  Used when :attr:`decoding_strategy` is ``"infer_greedy"`` or
+                  ``"infer_sample"``, or when :attr:`beam_search` is set.
 
         Returns:
 


### PR DESCRIPTION
Fix some of the doc issues mentioned in https://github.com/asyml/texar-pytorch/issues/259

- expose `DecoderBase` in doc
- delete unnecessary code in examples/gpt-2
- update doc of TransformerDecoder and RNNDecoderBase