### PR TITLE
Fix path error while installing on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
 
     packages=[
         f"texar.{name}"
-        for name in setuptools.find_packages(where='texar/')
+        for name in setuptools.find_packages(where='texar')
     ],
     platforms='any',
 


### PR DESCRIPTION
resolve #267 
I removed the slash "/" at the end of the string "texar/" and it works.