### PR TITLE
Add a new option to allow manually setting encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
 
     packages=[
         f"texar.{name}"
-        for name in setuptools.find_packages(where='texar')
+        for name in setuptools.find_packages(where='texar/')
     ],
     platforms='any',
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
 
     packages=[
         f"texar.{name}"
-        for name in setuptools.find_packages(where='texar/')
+        for name in setuptools.find_packages(where='texar')
     ],
     platforms='any',
 

--- a/texar/torch/data/data/mono_text_data.py
+++ b/texar/torch/data/data/mono_text_data.py
@@ -50,6 +50,7 @@ def _default_mono_text_dataset_hparams():
     return {
         "files": [],
         "compression_type": None,
+        "encoding": None,
         "vocab_file": "",
         "embedding_init": Embedding.default_hparams(),
         "delimiter": None,

--- a/texar/torch/data/data/paired_text_data.py
+++ b/texar/torch/data/data/paired_text_data.py
@@ -188,7 +188,7 @@ class PairedTextData(TextDataBase[Tuple[List[str], List[str]],
                                                   src_hparams.eos_token])
 
         src_data_source = TextLineDataSource(
-            src_hparams.files, compression_type=src_hparams.compression_type)
+            src_hparams.files, compression_type=src_hparams.compression_type, encoding=src_hparams.encoding)
 
         self._tgt_transforms = tgt_hparams["other_transformations"]
         self._tgt_delimiter = tgt_hparams.delimiter
@@ -202,7 +202,7 @@ class PairedTextData(TextDataBase[Tuple[List[str], List[str]],
                                                   tgt_hparams.eos_token])
 
         tgt_data_source = TextLineDataSource(
-            tgt_hparams.files, compression_type=tgt_hparams.compression_type)
+            tgt_hparams.files, compression_type=tgt_hparams.compression_type, encoding=tgt_hparams.encoding)
 
         data_source: DataSource[Tuple[List[str], List[str]]]
         data_source = ZipDataSource(  # type: ignore
@@ -233,6 +233,7 @@ class PairedTextData(TextDataBase[Tuple[List[str], List[str]],
                 "source_dataset": {
                     "files": [],
                     "compression_type": None,
+                    "encoding": None,
                     "vocab_file": "",
                     "embedding_init": {},
                     "delimiter": None,

--- a/texar/torch/data/vocabulary.py
+++ b/texar/torch/data/vocabulary.py
@@ -115,7 +115,7 @@ class Vocab:
             where and :attr:`token_to_id_map_py` are python `defaultdict`
             instances.
         """
-        with open(filename, "r") as vocab_file:
+        with open(filename, "r", encoding="utf-8") as vocab_file:
             vocab = list(line.strip() for line in vocab_file)
 
         warnings.simplefilter("ignore", UnicodeWarning)


### PR DESCRIPTION
resolve #270 
I can not load utf-8 file while building my vocabulary or loading my dataset because gbk is used by default on windows. I added a new option to allow manually setting encoding PairedTextData
```
$ python main.py 
Traceback (most recent call last):
  File "main.py", line 62, in <module>
    main()
  File "main.py", line 28, in main
    hparams=config_data.train, device=device)
  File "C:\Users\gaojun4ever\Miniconda3\lib\site-packages\texar\torch\data\data\paired_text_data.py", line 140, in __init__
    eos_token=src_hparams.eos_token)
  File "C:\Users\gaojun4ever\Miniconda3\lib\site-packages\texar\torch\data\vocabulary.py", line 103, in __init__
    = self.load(self._filename)
  File "C:\Users\gaojun4ever\Miniconda3\lib\site-packages\texar\torch\data\vocabulary.py", line 119, in load
    vocab = list(line.strip() for line in vocab_file)
  File "C:\Users\gaojun4ever\Miniconda3\lib\site-packages\texar\torch\data\vocabulary.py", line 119, in <genexpr>
    vocab = list(line.strip() for line in vocab_file)
UnicodeDecodeError: 'gbk' codec can't decode byte 0x8c in position 2: illegal multibyte sequence
```