### PR TITLE
Making the download_checkpoint pass even if the downloaded file isn't extracted into a new directory

### DIFF
--- a/texar/torch/modules/pretrained/pretrained_base.py
+++ b/texar/torch/modules/pretrained/pretrained_base.py
@@ -202,15 +202,19 @@ class PretrainedMixin(ModuleBase, ABC):
             if isinstance(download_path, str):
                 filename = download_path.split('/')[-1]
                 maybe_download(download_path, cache_path, extract=True)
+
+                # removing the compressed file
+                (cache_path / filename).unlink()
+
                 folder = None
+                # if extracted into a new directory
                 for file in cache_path.iterdir():
                     if file.is_dir():
                         folder = file
-                assert folder is not None
-                (cache_path / filename).unlink()
-                for file in folder.iterdir():
-                    file.rename(file.parents[1] / file.name)
-                folder.rmdir()
+                if folder is not None:
+                    for file in folder.iterdir():
+                        file.rename(file.parents[1] / file.name)
+                    folder.rmdir()
             else:
                 for path in download_path:
                     maybe_download(path, cache_path)


### PR DESCRIPTION
The download_checkpoint function assumes that the file will be extracted into a new directory but that isn't always the case.