### PR TITLE
Fixing the Google Drive download bug

### DIFF
--- a/texar/torch/data/data_utils.py
+++ b/texar/torch/data/data_utils.py
@@ -33,6 +33,7 @@ __all__ = [
     "read_words",
     "make_vocab",
     "count_file_lines",
+    "get_filename"
 ]
 
 Py3 = sys.version_info[0] == 3

--- a/texar/torch/data/data_utils.py
+++ b/texar/torch/data/data_utils.py
@@ -311,6 +311,8 @@ def count_file_lines(filenames: MaybeList[str]) -> int:
 
 
 def get_filename(url: str) -> str:
+    r"""Extracts the filename of the downloaded checkpoint file from the URL.
+    """
     if 'drive.google.com' in url:
         return _extract_google_drive_file_id(url)
     url, filename = os.path.split(url)

--- a/texar/torch/data/data_utils.py
+++ b/texar/torch/data/data_utils.py
@@ -139,6 +139,9 @@ def _download(url: str, filename: str, path: str) -> str:
 def _extract_google_drive_file_id(url: str) -> str:
     # id is between `/d/` and '/'
     url_suffix = url[url.find('/d/') + 3:]
+    if url_suffix.find('/') == -1:
+        # if there's no trailing '/'
+        return url_suffix
     file_id = url_suffix[:url_suffix.find('/')]
     return file_id
 
@@ -305,3 +308,10 @@ def count_file_lines(filenames: MaybeList[str]) -> int:
         filenames = [filenames]
     num_lines = np.sum([_count_lines(fn) for fn in filenames]).item()
     return num_lines
+
+
+def get_filename(url: str) -> str:
+    if 'drive.google.com' in url:
+        return _extract_google_drive_file_id(url)
+    url, filename = os.path.split(url)
+    return filename or os.path.basename(url)

--- a/texar/torch/modules/pretrained/pretrained_base.py
+++ b/texar/torch/modules/pretrained/pretrained_base.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional, Union
 from torch import nn
 
 from texar.torch.data.data_utils import maybe_download
+from texar.torch.data.data_utils import get_filename
 from texar.torch.hyperparams import HParams
 from texar.torch.module_base import ModuleBase
 from texar.torch.utils.types import MaybeList
@@ -200,7 +201,7 @@ class PretrainedMixin(ModuleBase, ABC):
 
         if not cache_path.exists():
             if isinstance(download_path, str):
-                filename = download_path.split('/')[-1]
+                filename = get_filename(download_path)
                 maybe_download(download_path, cache_path, extract=True)
                 folder = None
                 for file in cache_path.iterdir():

--- a/texar/torch/modules/pretrained/pretrained_base.py
+++ b/texar/torch/modules/pretrained/pretrained_base.py
@@ -22,8 +22,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from torch import nn
 
-from texar.torch.data.data_utils import maybe_download
-from texar.torch.data.data_utils import get_filename
+from texar.torch.data.data_utils import maybe_download, get_filename
 from texar.torch.hyperparams import HParams
 from texar.torch.module_base import ModuleBase
 from texar.torch.utils.types import MaybeList


### PR DESCRIPTION
When downloading from Google Drive we use the `file_id` for saving the download file name. But when deleting that same file after extracting in `download_checkpoint` method, we get the filename from the URL which can be different in many cases.

Also, in `_extract_google_drive_file_id` method, we should be able to extract the `file_id` even if there's no trailing `/` in the URL.