### PR TITLE
Adding BERT for MS-MARCO Passage re-ranking

### DIFF
--- a/texar/torch/data/tokenizers/bert_tokenizer.py
+++ b/texar/torch/data/tokenizers/bert_tokenizer.py
@@ -74,6 +74,10 @@ class BERTTokenizer(PretrainedBERTMixin, TokenizerBase):
         'scibert-scivocab-cased': 512,
         'scibert-basevocab-uncased': 512,
         'scibert-basevocab-cased': 512,
+
+        # BERT for MS-MARCO
+        'bert-msmarco-base': 512,
+        'bert-msmarco-large': 512,
     }
     _VOCAB_FILE_NAMES = {'vocab_file': 'vocab.txt'}
     _VOCAB_FILE_MAP = {
@@ -98,6 +102,10 @@ class BERTTokenizer(PretrainedBERTMixin, TokenizerBase):
             'scibert-scivocab-cased': 'vocab.txt',
             'scibert-basevocab-uncased': 'vocab.txt',
             'scibert-basevocab-cased': 'vocab.txt',
+
+            # BERT for MS-MARCO
+            'bert-msmarco-base': 'vocab.txt',
+            'bert-msmarco-large': 'vocab.txt',
         }
     }
 

--- a/texar/torch/data/tokenizers/bert_tokenizer.py
+++ b/texar/torch/data/tokenizers/bert_tokenizer.py
@@ -76,8 +76,8 @@ class BERTTokenizer(PretrainedBERTMixin, TokenizerBase):
         'scibert-basevocab-cased': 512,
 
         # BERT for MS-MARCO
-        'bert-msmarco-base': 512,
-        'bert-msmarco-large': 512,
+        'bert-msmarco-nogueira19-base': 512,
+        'bert-msmarco-nogueira19-large': 512,
     }
     _VOCAB_FILE_NAMES = {'vocab_file': 'vocab.txt'}
     _VOCAB_FILE_MAP = {
@@ -104,8 +104,8 @@ class BERTTokenizer(PretrainedBERTMixin, TokenizerBase):
             'scibert-basevocab-cased': 'vocab.txt',
 
             # BERT for MS-MARCO
-            'bert-msmarco-base': 'vocab.txt',
-            'bert-msmarco-large': 'vocab.txt',
+            'bert-msmarco-nogueira19-base': 'vocab.txt',
+            'bert-msmarco-nogueira19-large': 'vocab.txt',
         }
     }
 

--- a/texar/torch/modules/classifiers/bert_classifier.py
+++ b/texar/torch/modules/classifiers/bert_classifier.py
@@ -76,9 +76,10 @@ class BERTClassifier(ClassifierBase, PretrainedBERTMixin):
         # Create the underlying encoder
         encoder_hparams = dict_fetch(hparams,
                                      self._ENCODER_CLASS.default_hparams())
+        encoder_hparams['pretrained_model_name'] = None
 
         self._encoder = self._ENCODER_CLASS(
-            pretrained_model_name=pretrained_model_name,
+            pretrained_model_name=None,
             cache_dir=cache_dir,
             hparams=encoder_hparams)
 

--- a/texar/torch/modules/classifiers/bert_classifier.py
+++ b/texar/torch/modules/classifiers/bert_classifier.py
@@ -71,6 +71,8 @@ class BERTClassifier(ClassifierBase, PretrainedBERTMixin):
 
         super().__init__(hparams=hparams)
 
+        self.load_pretrained_config(pretrained_model_name, cache_dir)
+
         # Create the underlying encoder
         encoder_hparams = dict_fetch(hparams,
                                      self._ENCODER_CLASS.default_hparams())
@@ -119,6 +121,8 @@ class BERTClassifier(ClassifierBase, PretrainedBERTMixin):
         self.is_binary = (self.num_classes == 1) or \
                          (self.num_classes <= 0 and
                           self._hparams.encoder.dim == 1)
+
+        self.init_pretrained_weights(class_type='classifier')
 
     @staticmethod
     def default_hparams():

--- a/texar/torch/modules/pretrained/bert.py
+++ b/texar/torch/modules/pretrained/bert.py
@@ -123,7 +123,7 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
     .. _`SciBERT: A Pretrained Language Model for Scientific Text`:
         https://arxiv.org/abs/1903.10676
 
-    .. _`BERT for MS-MARCO: Passage re-ranking with BERT`:
+    .. _`Passage re-ranking with BERT`:
         https://arxiv.org/abs/1901.04085
     """
 

--- a/texar/torch/modules/pretrained/bert.py
+++ b/texar/torch/modules/pretrained/bert.py
@@ -34,7 +34,7 @@ _BERT_PATH = "https://storage.googleapis.com/bert_models/"
 _BIOBERT_PATH = "https://github.com/naver/biobert-pretrained/releases/download/"
 _SCIBERT_PATH = "https://s3-us-west-2.amazonaws.com/ai2-s2-research/" \
                 "scibert/tensorflow_models/"
-_BERT_MSMARCO_PATH = "https://drive.google.com/file/d/"
+_BERT_MSMARCO_NOGUEIRA19_PATH = "https://drive.google.com/file/d/"
 
 
 class PretrainedBERTMixin(PretrainedMixin, ABC):
@@ -103,9 +103,9 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
       (`Nguyen et al`., 2016) dataset. It's the best performing model (on Jan
       8th 2019) on MS-MARCO Passage re-ranking task. Two models are included:
 
-        * ``bert-msmarco-base``: Original BERT base model fine-tuned on
+        * ``bert-msmarco-nogueira19-base``: Original BERT base model fine-tuned on
           MS-MARCO.
-        * ``bert-msmarco-large``: Original BERT large model fine-tuned on
+        * ``bert-msmarco-nogueira19-large``: Original BERT large model fine-tuned on
           MS-MARCO.
 
     We provide the following BERT classes:
@@ -167,9 +167,9 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
 
         # BERT for MS-MARCO
         'bert-msmarco-base':
-            _BERT_MSMARCO_PATH + '1cyUrhs7JaCJTTu-DjFUqP6Bs4f8a6JTX/',
+            _BERT_MSMARCO_NOGUEIRA19_PATH + '1cyUrhs7JaCJTTu-DjFUqP6Bs4f8a6JTX/',
         'bert-msmarco-large':
-            _BERT_MSMARCO_PATH + '1crlASTMlsihALlkabAQP6JTYIZwC1Wm8/'
+            _BERT_MSMARCO_NOGUEIRA19_PATH + '1crlASTMlsihALlkabAQP6JTYIZwC1Wm8/'
     }
     _MODEL2CKPT = {
         # Standard BERT
@@ -194,8 +194,8 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
         'scibert-basevocab-cased': 'bert_model.ckpt',
 
         # BERT for MSMARCO
-        'bert-msmarco-base': 'model.ckpt-100000',
-        'bert-msmarco-large': 'model.ckpt-100000',
+        'bert-msmarco-nogueira19-base': 'model.ckpt-100000',
+        'bert-msmarco-nogueira19-large': 'model.ckpt-100000',
     }
 
     @classmethod

--- a/texar/torch/modules/pretrained/bert.py
+++ b/texar/torch/modules/pretrained/bert.py
@@ -166,9 +166,9 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
             _SCIBERT_PATH + 'scibert_basevocab_cased.tar.gz',
 
         # BERT for MS-MARCO
-        'bert-msmarco-base':
+        'bert-msmarco-nogueira19-base':
             _BERT_MSMARCO_NOGUEIRA19_PATH + '1cyUrhs7JaCJTTu-DjFUqP6Bs4f8a6JTX/',
-        'bert-msmarco-large':
+        'bert-msmarco-nogueira19-large':
             _BERT_MSMARCO_NOGUEIRA19_PATH + '1crlASTMlsihALlkabAQP6JTYIZwC1Wm8/'
     }
     _MODEL2CKPT = {

--- a/texar/torch/modules/pretrained/bert.py
+++ b/texar/torch/modules/pretrained/bert.py
@@ -123,7 +123,7 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
     .. _`SciBERT: A Pretrained Language Model for Scientific Text`:
         https://arxiv.org/abs/1903.10676
 
-    .. _`Passage re-ranking with BERT`:
+    .. _`Passage Re-ranking with BERT`:
         https://arxiv.org/abs/1901.04085
     """
 

--- a/texar/torch/modules/pretrained/bert.py
+++ b/texar/torch/modules/pretrained/bert.py
@@ -34,6 +34,7 @@ _BERT_PATH = "https://storage.googleapis.com/bert_models/"
 _BIOBERT_PATH = "https://github.com/naver/biobert-pretrained/releases/download/"
 _SCIBERT_PATH = "https://s3-us-west-2.amazonaws.com/ai2-s2-research/" \
                 "scibert/tensorflow_models/"
+_BERT_MSMARCO_PATH = "https://drive.google.com/file/d/"
 
 
 class PretrainedBERTMixin(PretrainedMixin, ABC):
@@ -97,6 +98,16 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
         * ``scibert-basevocab-cased``: Cased version of the model trained on
           the original BERT vocabulary.
 
+    * **BERT for MS-MARCO**: proposed in (`Nogueira et al`. 2019)
+      `Passage Re-ranking with BERT`_. A BERT model fine-tuned on MS-MARCO
+      (Nguyen et al., 2016) dataset. It's the best performing model (on Jan 8th
+      2019) on MS-MARCO Passage re-ranking task. Two models are included:
+
+        * ``bert-msmarco-base``: Original BERT base model fine-tuned on
+          MS-MARCO.
+        * ``bert-msmarco-large``: Original BERT large model fine-tuned on
+          MS-MARCO.
+
     We provide the following BERT classes:
 
       * :class:`~texar.torch.modules.BERTEncoder` for text encoding.
@@ -111,6 +122,9 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
 
     .. _`SciBERT: A Pretrained Language Model for Scientific Text`:
         https://arxiv.org/abs/1903.10676
+
+    .. _`BERT for MS-MARCO: Passage re-ranking with BERT`:
+        https://arxiv.org/abs/1901.04085
     """
 
     _MODEL_NAME = "BERT"
@@ -150,6 +164,12 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
             _SCIBERT_PATH + 'scibert_basevocab_uncased.tar.gz',
         'scibert-basevocab-cased':
             _SCIBERT_PATH + 'scibert_basevocab_cased.tar.gz',
+
+        # BERT for MS-MARCO
+        'bert-msmarco-base':
+            _BERT_MSMARCO_PATH + '1cyUrhs7JaCJTTu-DjFUqP6Bs4f8a6JTX/view',
+        'bert-msmarco-large':
+            _BERT_MSMARCO_PATH + '1crlASTMlsihALlkabAQP6JTYIZwC1Wm8/view'
     }
     _MODEL2CKPT = {
         # Standard BERT
@@ -172,6 +192,10 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
         'scibert-scivocab-cased': 'bert_model.ckpt',
         'scibert-basevocab-uncased': 'bert_model.ckpt',
         'scibert-basevocab-cased': 'bert_model.ckpt',
+
+        # BERT for MSMARCO
+        'bert-msmarco-base': 'model.ckpt-100000',
+        'bert-msmarco-large': 'model.ckpt-100000',
     }
 
     @classmethod

--- a/texar/torch/modules/pretrained/bert.py
+++ b/texar/torch/modules/pretrained/bert.py
@@ -100,8 +100,8 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
 
     * **BERT for MS-MARCO**: proposed in (`Nogueira et al`. 2019)
       `Passage Re-ranking with BERT`_. A BERT model fine-tuned on MS-MARCO
-      (`Nguyen et al`., 2016) dataset. It's the best performing model (on Jan 8th
-      2019) on MS-MARCO Passage re-ranking task. Two models are included:
+      (`Nguyen et al`., 2016) dataset. It's the best performing model (on Jan
+      8th 2019) on MS-MARCO Passage re-ranking task. Two models are included:
 
         * ``bert-msmarco-base``: Original BERT base model fine-tuned on
           MS-MARCO.

--- a/texar/torch/modules/pretrained/bert.py
+++ b/texar/torch/modules/pretrained/bert.py
@@ -167,9 +167,9 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
 
         # BERT for MS-MARCO
         'bert-msmarco-base':
-            _BERT_MSMARCO_PATH + '1cyUrhs7JaCJTTu-DjFUqP6Bs4f8a6JTX/view',
+            _BERT_MSMARCO_PATH + '1cyUrhs7JaCJTTu-DjFUqP6Bs4f8a6JTX/',
         'bert-msmarco-large':
-            _BERT_MSMARCO_PATH + '1crlASTMlsihALlkabAQP6JTYIZwC1Wm8/view'
+            _BERT_MSMARCO_PATH + '1crlASTMlsihALlkabAQP6JTYIZwC1Wm8/'
     }
     _MODEL2CKPT = {
         # Standard BERT
@@ -325,7 +325,9 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
         }
         pooler_map = {
             'bert/pooler/dense/bias': 'pooler.0.bias',
-            'bert/pooler/dense/kernel': 'pooler.0.weight'
+            'bert/pooler/dense/kernel': 'pooler.0.weight',
+            'output_bias': '_logits_layer.bias',
+            'output_weights': '_logits_layer.weight',
         }
         tf_path = os.path.abspath(os.path.join(
             cache_dir, self._MODEL2CKPT[pretrained_model_name]))

--- a/texar/torch/modules/pretrained/bert.py
+++ b/texar/torch/modules/pretrained/bert.py
@@ -100,7 +100,7 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
 
     * **BERT for MS-MARCO**: proposed in (`Nogueira et al`. 2019)
       `Passage Re-ranking with BERT`_. A BERT model fine-tuned on MS-MARCO
-      (Nguyen et al., 2016) dataset. It's the best performing model (on Jan 8th
+      (`Nguyen et al`., 2016) dataset. It's the best performing model (on Jan 8th
       2019) on MS-MARCO Passage re-ranking task. Two models are included:
 
         * ``bert-msmarco-base``: Original BERT base model fine-tuned on

--- a/texar/torch/modules/pretrained/bert.py
+++ b/texar/torch/modules/pretrained/bert.py
@@ -103,10 +103,10 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
       (`Nguyen et al`., 2016) dataset. It's the best performing model (on Jan
       8th 2019) on MS-MARCO Passage re-ranking task. Two models are included:
 
-        * ``bert-msmarco-nogueira19-base``: Original BERT base model fine-tuned on
-          MS-MARCO.
-        * ``bert-msmarco-nogueira19-large``: Original BERT large model fine-tuned on
-          MS-MARCO.
+        * ``bert-msmarco-nogueira19-base``: Original BERT base model fine-tuned
+          on MS-MARCO.
+        * ``bert-msmarco-nogueira19-large``: Original BERT large model
+          fine-tuned on MS-MARCO.
 
     We provide the following BERT classes:
 
@@ -167,7 +167,7 @@ class PretrainedBERTMixin(PretrainedMixin, ABC):
 
         # BERT for MS-MARCO
         'bert-msmarco-nogueira19-base':
-            _BERT_MSMARCO_NOGUEIRA19_PATH + '1cyUrhs7JaCJTTu-DjFUqP6Bs4f8a6JTX/',
+            _BERT_MSMARCO_NOGUEIRA19_PATH + '1cyUrhs7JaCJTTu-DjFUqP6Bs4f8a6JTX',
         'bert-msmarco-nogueira19-large':
             _BERT_MSMARCO_NOGUEIRA19_PATH + '1crlASTMlsihALlkabAQP6JTYIZwC1Wm8/'
     }


### PR DESCRIPTION
Adding BERT fine-tuned on MS-MARCO for passage re-ranking task (https://arxiv.org/abs/1901.04085)

Since this is a pretrained classifier, we had to add final linear layer parameters in `PretrainedBERTMixin`. Based on the `pretrained_model_name`, the weights of the final classifier layer will be loaded if they are present.

resolve #254 