### PR TITLE
Fix bugs in Executor

### DIFF
--- a/docs/code/data.rst
+++ b/docs/code/data.rst
@@ -132,9 +132,6 @@ Data Loaders
 .. autoclass:: texar.torch.data.DatasetBase
     :members:
 
-    .. automethod:: process
-    .. automethod:: collate
-
 :hidden:`MonoTextData`
 ~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: texar.torch.data.MonoTextData

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -1147,16 +1147,8 @@ class Executor:
             torch.save(train_state, str(ckpt_path))
         else:
             torch.save(self.model.state_dict(), str(ckpt_path))
-
-        # Convert the metric dictionaries to values, to avoid saving metric
-        # instances, as they may carry large chunks of data or not be
-        # pickle-able.
-        status_dict = self.status.copy()
-        status_dict["metric"] = utils.to_metric_values(status_dict["metric"])
-        status_dict["eval_metric"] = utils.to_metric_values(
-            status_dict["eval_metric"])
         meta_dict[checkpoint_name] = {
-            "status": status_dict,
+            "status": self.status,
             "timestamp": timestamp,
         }
         with meta_path.open("wb") as f:

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -1147,8 +1147,16 @@ class Executor:
             torch.save(train_state, str(ckpt_path))
         else:
             torch.save(self.model.state_dict(), str(ckpt_path))
+
+        # Convert the metric dictionaries to values, to avoid saving metric
+        # instances, as they may carry large chunks of data or not be
+        # pickle-able.
+        status_dict = self.status.copy()
+        status_dict["metric"] = utils.to_metric_values(status_dict["metric"])
+        status_dict["eval_metric"] = utils.to_metric_values(
+            status_dict["eval_metric"])
         meta_dict[checkpoint_name] = {
-            "status": self.status,
+            "status": status_dict,
             "timestamp": timestamp,
         }
         with meta_path.open("wb") as f:

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -1909,7 +1909,7 @@ class Executor:
             self._fire_event(Event.ValidationIteration, False)
             return_dict = self._validate_step(batch)
 
-            # Update metrics.
+            self._valid_tracker.add(len(batch))
             utils.update_metrics(return_dict, batch, self.valid_metrics)
 
             self._fire_event(Event.ValidationIteration, True)
@@ -1925,8 +1925,7 @@ class Executor:
             return_dict = self._test_step(batch)
 
             self._test_tracker.add(len(batch))
-            utils.update_metrics(
-                return_dict, batch, self.test_metrics)
+            utils.update_metrics(return_dict, batch, self.test_metrics)
 
             self._fire_event(Event.TestingIteration, True)
 

--- a/texar/torch/run/executor_utils.py
+++ b/texar/torch/run/executor_utils.py
@@ -50,7 +50,6 @@ __all__ = [
 ]
 
 T = TypeVar('T')
-R = TypeVar('R')
 OptionalList = Optional[MaybeSeq[T]]
 OptionalDict = Optional[Union[T, Sequence[Union[T, Tuple[str, T]]],
                               Mapping[str, T]]]
@@ -293,12 +292,6 @@ class MetricList:
             if cmp is not None:
                 return cmp
         return False
-
-
-def to_metric_values(metric_dict: 'OrderedDict[str, Metric[T, R]]') \
-        -> 'OrderedDict[str, R]':
-    return OrderedDict(
-        [(name, metric.value()) for name, metric in metric_dict.items()])
 
 
 def update_metrics(return_dict: Dict[str, Any], batch: Batch,

--- a/texar/torch/run/executor_utils.py
+++ b/texar/torch/run/executor_utils.py
@@ -50,6 +50,7 @@ __all__ = [
 ]
 
 T = TypeVar('T')
+R = TypeVar('R')
 OptionalList = Optional[MaybeSeq[T]]
 OptionalDict = Optional[Union[T, Sequence[Union[T, Tuple[str, T]]],
                               Mapping[str, T]]]
@@ -292,6 +293,12 @@ class MetricList:
             if cmp is not None:
                 return cmp
         return False
+
+
+def to_metric_values(metric_dict: 'OrderedDict[str, Metric[T, R]]') \
+        -> 'OrderedDict[str, R]':
+    return OrderedDict(
+        [(name, metric.value()) for name, metric in metric_dict.items()])
 
 
 def update_metrics(return_dict: Dict[str, Any], batch: Batch,

--- a/texar/torch/run/metric/summary.py
+++ b/texar/torch/run/metric/summary.py
@@ -165,3 +165,13 @@ class LR(StreamingMetric[Any, float]):
     def better(self, cur: float, prev: float) -> Optional[bool]:
         # Always return `None` to indicate values are uncomparable.
         return None
+
+    def __getstate__(self):
+        # There's no point in pickling an `LR` metric; just ignore it.
+        return None
+
+    def __getnewargs__(self):
+        # But when unpickling, we need to make sure we can construct something.
+        # This requires passing a dummy `optimizer` to which a weakref can be
+        # constructed. In this case, we use an arbitrary built-in class.
+        return (int,)

--- a/texar/torch/run/metric/summary.py
+++ b/texar/torch/run/metric/summary.py
@@ -17,6 +17,7 @@ Executor metrics for summaries.
 
 from collections import deque
 from typing import Any, Deque, Optional, Sequence
+import weakref
 
 import numpy as np
 from torch.optim.optimizer import Optimizer
@@ -152,14 +153,14 @@ class LR(StreamingMetric[Any, float]):
 
     def __init__(self, optimizer: Optimizer, param_group: int = 0):
         super().__init__(pred_name=None)
-        self.optimizer = optimizer
+        self.optimizer = weakref.ref(optimizer)
         self.group = param_group
 
     def add(self, _, __):
         pass
 
     def value(self) -> float:
-        return self.optimizer.param_groups[self.group]['lr']  # type: ignore
+        return self.optimizer().param_groups[self.group]['lr']  # type: ignore
 
     def better(self, cur: float, prev: float) -> Optional[bool]:
         # Always return `None` to indicate values are uncomparable.


### PR DESCRIPTION
This PR fixes a bunch of bugs in the Executor module:

#### Missing call to tracker in `_validate_loop`

This is so stupid: for some reason I forgot to call `_valid_tracker.add` in `_validate_loop`, so the status is never updated during validation.

#### Files closed prematurely when `test` is called in `train`.

`_open_files` and `_close_files` are called at the beginning and end of `train` and `test`, to prevent holding on to an open file object for an unnecessarily long amount of time.

However, it's possible that we call `test` within `train`. For instance, calling `test` in a action triggered by the validation event. In this case, the file will be closed before training ends.

_Solution:_ Check whether we need to open files, and if we don't, then don't open or close them.

#### Saved `meta-info` contains large bulks of data

The saved `meta-info` in the checkpoints directory contains the training and evaluation metrics at the time of save, but we were actually saving the metric objects. This is unnecessary as we only need the values.

What's more is that some metric objects stores reference to large objects. For instance, the `LR` metric stored a reference to the optimizer, which holds a bunch of weights. This made the `meta-info` even larger in size than the checkpoints.

_Solution:_
1. Save only metric values.
2. Store the optimizer as a `weakref` in `LR`.