### PR TITLE
Fix #318 cannot pickle metrics

### DIFF
--- a/tests/run/executor_test.py
+++ b/tests/run/executor_test.py
@@ -111,7 +111,7 @@ class ExecutorTest(unittest.TestCase):
             save_every=[cond.time(seconds=10), cond.validation(better=True)],
             train_metrics=[("loss", metric.RunningAverage(20)),
                            metric.F1(pred_name="preds", mode="macro"),
-                           metric.Accuracy(pred_name="preds"),
+                           metric.Accuracy[float](pred_name="preds"),
                            metric.LR(optimizer)],
             optimizer=optimizer,
             stop_training_on=cond.epoch(10),

--- a/tests/run/metric/classification_test.py
+++ b/tests/run/metric/classification_test.py
@@ -15,6 +15,7 @@
 Unit tests for classification related operations.
 """
 import functools
+import pickle
 import unittest
 
 import numpy as np
@@ -74,3 +75,18 @@ class ClassificationMetricTest(unittest.TestCase):
             self._test_metric(
                 metric, functools.partial(f1_score, average=mode),
                 binary=(mode == 'binary'))
+
+
+class MetricPicklingTest(unittest.TestCase):
+    def test_pickle_unpickle(self):
+        metric = Accuracy(pred_name="123")
+        metric.add([1, 2, 3], [1, 2, 4])
+        metric_new = pickle.loads(pickle.dumps(metric))
+        self.assertEqual(metric.count, metric_new.count)
+        self.assertEqual(metric.correct, metric_new.correct)
+
+        metric = Accuracy[float](pred_name="123")
+        metric.add([1, 2, 3], [1, 2, 4])
+        metric_new = pickle.loads(pickle.dumps(metric))
+        self.assertEqual(metric.count, metric_new.count)
+        self.assertEqual(metric.correct, metric_new.correct)

--- a/texar/torch/run/metric/base_metric.py
+++ b/texar/torch/run/metric/base_metric.py
@@ -14,9 +14,9 @@
 """
 Base classes for Executor metrics.
 """
-
+import sys
 from abc import ABC, abstractmethod
-from typing import Generic, List, Optional, Sequence, TypeVar
+from typing import Generic, List, Optional, Sequence, TYPE_CHECKING, TypeVar
 
 __all__ = [
     "Metric",
@@ -26,6 +26,23 @@ __all__ = [
 
 Input = TypeVar('Input')
 Value = TypeVar('Value')
+
+if not TYPE_CHECKING and sys.version_info[:2] <= (3, 6):
+    # In Python 3.6 and below, pickling a `Generic` subclass that is specialized
+    # would cause an exception. To prevent troubles with `Executor` save & load,
+    # we use a dummy implementation of `Generic` through our home-brew
+    # `GenericMeta`.
+    from abc import ABCMeta
+
+
+    class GenericMeta(ABCMeta):
+        def __getitem__(cls, params):
+            # Whatever the parameters, just return the same class.
+            return cls
+
+
+    class Generic(metaclass=GenericMeta):
+        pass
 
 
 class Metric(Generic[Input, Value], ABC):

--- a/texar/torch/run/metric/base_metric.py
+++ b/texar/torch/run/metric/base_metric.py
@@ -32,16 +32,14 @@ if not TYPE_CHECKING and sys.version_info[:2] <= (3, 6):
     # would cause an exception. To prevent troubles with `Executor` save & load,
     # we use a dummy implementation of `Generic` through our home-brew
     # `GenericMeta`.
-    from abc import ABCMeta
-
+    from abc import ABCMeta  # pylint: disable=ungrouped-imports
 
     class GenericMeta(ABCMeta):
         def __getitem__(cls, params):
             # Whatever the parameters, just return the same class.
             return cls
 
-
-    class Generic(metaclass=GenericMeta):
+    class Generic(metaclass=GenericMeta):  # pylint: disable=function-redefined
         pass
 
 


### PR DESCRIPTION
This PR fixes #318: cannot pickle metrics in Python 3.6.

In Python 3.6 and below, pickling a `Generic` subclass that is specialized (e.g., `Accuracy[float]`) would cause an exception. To prevent troubles with `Executor` save & load, we use a dummy implementation of `Generic` through our home-brew `GenericMeta`. Basically, it is modified so that for any class `Foo` that inherits from `Generic`, `Foo[T]` just returns `Foo`.

Additional unit tests are also added to verify pickling behavior.