### PR TITLE
Fix a couple of Executor bugs

### DIFF
--- a/examples/bert/bert_classifier_main.py
+++ b/examples/bert/bert_classifier_main.py
@@ -211,6 +211,7 @@ def main() -> None:
         output_file = os.path.join(args.output_dir, "test_results.tsv")
         with open(output_file, "w+") as writer:
             writer.write("\n".join(str(p) for p in _all_preds))
+        logging.info("test output written to %s", output_file)
 
     if args.checkpoint:
         ckpt = torch.load(args.checkpoint)

--- a/examples/bert/bert_classifier_using_executor_main.py
+++ b/examples/bert/bert_classifier_using_executor_main.py
@@ -20,9 +20,8 @@ import functools
 import importlib
 import os
 import sys
-import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Tuple
 
 import torch
 from torch import nn

--- a/examples/bert/bert_classifier_using_executor_main.py
+++ b/examples/bert/bert_classifier_using_executor_main.py
@@ -99,18 +99,6 @@ class ModelWrapper(nn.Module):
         return {"preds": preds}
 
 
-class FileWriterMetric(metric.SimpleMetric[List[int], float]):
-    def __init__(self, file_path: Optional[Union[str, Path]] = None):
-        super().__init__(pred_name="preds", label_name="input_ids")
-        self.file_path = file_path
-
-    def _value(self) -> float:
-        path = self.file_path or tempfile.mktemp()
-        with open(path, "w+") as writer:
-            writer.write("\n".join(str(p) for p in self.predicted))
-        return 1.0
-
-
 def main() -> None:
     """
     Builds the model and runs.
@@ -205,7 +193,8 @@ def main() -> None:
         valid_metrics=[
             metric.Accuracy[float](pred_name="preds", label_name="label_ids"),
             ("loss", metric.Average())],
-        test_metrics=FileWriterMetric(test_output_path),  # only write to file
+        test_metrics=[  # only write to file
+            metric.FileWriterMetric(test_output_path, pred_name="preds")],
         # freq of validation
         validate_every=[cond.iteration(config_data.eval_steps)],
         # checkpoint saving location

--- a/examples/bert/bert_classifier_using_executor_main.py
+++ b/examples/bert/bert_classifier_using_executor_main.py
@@ -167,8 +167,7 @@ def main() -> None:
         max_tokens=config_data.max_batch_tokens)
 
     output_dir = Path(args.output_dir)
-    valid_metric = metric.Accuracy[float](
-        pred_name="preds", label_name="label_ids")
+    test_output_path = output_dir / "test.output"
 
     executor = Executor(
         # supply executor with the model
@@ -198,14 +197,15 @@ def main() -> None:
         valid_progress_log_format="{time} : Evaluating on "
                                   "{split} ({progress}%, {speed})",
         test_log_format="{time} : Epoch {epoch}, "
-                        "{split} accuracy = {Accuracy:.3f}",
+                        "{split} results written to " + str(test_output_path),
         # define metrics
         train_metrics=[
             ("loss", metric.RunningAverage(1)),  # only show current loss
             ("lr", metric.LR(optim))],
-        valid_metrics=[valid_metric, ("loss", metric.Average())],
-        test_metrics=[
-            valid_metric, FileWriterMetric(output_dir / "test.output")],
+        valid_metrics=[
+            metric.Accuracy[float](pred_name="preds", label_name="label_ids"),
+            ("loss", metric.Average())],
+        test_metrics=FileWriterMetric(test_output_path),  # only write to file
         # freq of validation
         validate_every=[cond.iteration(config_data.eval_steps)],
         # checkpoint saving location

--- a/texar/torch/run/action.py
+++ b/texar/torch/run/action.py
@@ -50,7 +50,7 @@ class scale_lr(Action):
     def __call__(self, executor: Executor):
         new_lr = []
         assert executor.optimizer is not None
-        for group in executor.optimizer.param_groups:
+        for group in executor.optimizer.param_groups:  # type: ignore
             lr = group['lr'] * self.scale
             group['lr'] = lr
             new_lr.append(lr)

--- a/texar/torch/run/action.py
+++ b/texar/torch/run/action.py
@@ -50,7 +50,7 @@ class scale_lr(Action):
     def __call__(self, executor: Executor):
         new_lr = []
         assert executor.optimizer is not None
-        for group in executor.optimizer.param_groups:  # type: ignore
+        for group in executor.optimizer.param_groups:
             lr = group['lr'] * self.scale
             group['lr'] = lr
             new_lr.append(lr)

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -909,6 +909,7 @@ class Executor:
         self._register_logging_actions(show_live_progress)
 
         # tbx logging
+        self.summary_writer = None
         self._tbx_logging_dir = tbx_logging_dir
         if tbx_logging_dir is not None:
             # Instantiation of the summary writer is delayed to `_open_files`.
@@ -1528,7 +1529,6 @@ class Executor:
             Event.TestingIteration, Event.Testing)
 
     def _register_tbx_logging_actions(self):
-
         # Register logging actions.
         Points = Sequence[Union[Condition, Event]]
 
@@ -1540,16 +1540,15 @@ class Executor:
                     self._register_hook((cond_or_event, True), fn)
 
         def tbx_train_log_fn(executor: 'Executor'):
+            assert self.summary_writer is not None
             train_metrics = executor.train_metrics
-
-            # log the metrics here
             for key, value in train_metrics.items():
                 self.summary_writer.add_scalar(
                     f"train/{key}", value.value(), executor.status["iteration"])
 
         def tbx_valid_log_fn(executor: 'Executor'):
+            assert self.summary_writer is not None
             valid_metrics = executor.valid_metrics
-
             for key, value in valid_metrics.items():
                 self.summary_writer.add_scalar(
                     f"valid/{key}", value.value(), executor.status["iteration"])
@@ -1769,7 +1768,7 @@ class Executor:
         self._opened_files = []
         self._log_destination = []
 
-        if hasattr(self, 'summary_writer'):
+        if self.summary_writer is not None:
             self.summary_writer.close()
 
         self._files_opened = False

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -1196,7 +1196,7 @@ class Executor:
                          info["timestamp"], name)
                         for name, info in meta_dict.items())
                     status = meta_dict[best_ckpt_name]["status"]
-                    ckpt_path = self.checkpoint_dir / best_ckpt_name
+                    ckpt_path = ckpt_path / best_ckpt_name
                     metric_vals = [(name, best_metric.values[name])
                                    for name in best_metric.metrics]
                     metric_str = ", ".join(

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -1656,7 +1656,8 @@ class Executor:
             for name, metric in metrics.items():
                 try:
                     value = metric.value()
-                    if value is None: continue  # skip non-meaningful metrics
+                    if value is None:
+                        continue  # skip non-meaningful metrics
                     metrics_to_keep.append(name)
                     metric_format.format(metric.value())
                     fmt_metrics.add(name)

--- a/texar/torch/run/metric/__init__.py
+++ b/texar/torch/run/metric/__init__.py
@@ -18,5 +18,6 @@ Metrics for the Executor module.
 from texar.torch.run.metric.base_metric import *
 from texar.torch.run.metric.classification import *
 from texar.torch.run.metric.generation import *
+from texar.torch.run.metric.io import *
 from texar.torch.run.metric.regression import *
 from texar.torch.run.metric.summary import *

--- a/texar/torch/run/metric/base_metric.py
+++ b/texar/torch/run/metric/base_metric.py
@@ -14,6 +14,7 @@
 """
 Base classes for Executor metrics.
 """
+
 import sys
 from abc import ABC, abstractmethod
 from typing import Generic, List, Optional, Sequence, TYPE_CHECKING, TypeVar
@@ -157,6 +158,19 @@ class Metric(Generic[Input, Value], ABC):
             result = not result
         return result
 
+    def finalize(self, executor) -> None:
+        r"""Finalize the metric. Called when the whole dataset has been fully
+        iterated, e.g., at the end of an epoch, or the end of validation or
+        testing.
+
+        The default behavior is no-op. Most metrics won't need this, special
+        ones such as :class:`FileWriterMetric` utilizes this to performs
+        one-time only operations.
+
+        Args:
+            executor: The :class:`Executor` instance.
+        """
+
 
 class SimpleMetric(Metric[Input, Value], ABC):
     r"""Base class of simple metrics. Simple metrics are metrics that do not
@@ -176,11 +190,14 @@ class SimpleMetric(Metric[Input, Value], ABC):
         self._cached_value = None
 
     def add(self, predicted: Sequence[Input], labels: Sequence[Input]):
-        if len(predicted) != len(labels):
+        if (self.requires_pred and self.requires_label and
+                len(predicted) != len(labels)):
             raise ValueError(
                 "Lists `predicted` and `labels` should have the same length")
-        self.predicted.extend(predicted)
-        self.labels.extend(labels)
+        if self.requires_pred:
+            self.predicted.extend(predicted)
+        if self.requires_label:
+            self.labels.extend(labels)
         self._cached_value = None
 
     def value(self):

--- a/texar/torch/run/metric/io.py
+++ b/texar/torch/run/metric/io.py
@@ -1,0 +1,68 @@
+# Copyright 2019 The Texar Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Executor metrics that are actually not metrics, but for IO.
+"""
+from pathlib import Path
+from typing import TypeVar, Sequence, Union
+
+from texar.torch.run.metric.base_metric import SimpleMetric
+from texar.torch.utils.types import PathLike
+
+__all__ = [
+    "FileWriterMetric",
+]
+
+Input = TypeVar('Input')
+Value = TypeVar('Value')
+
+
+class FileWriterMetric(SimpleMetric[Input, None]):
+    r"""A metric for writing predictions to file.
+
+    Args:
+        file_path: Path to the output file. You can include :class:`Executor`
+            status variables in the path using Python's string formatting
+            syntax. For example, ``output_{split}_{epoch}.txt`` will resolve to
+            ``output_test_1.txt`` if the metric is used in testing after
+            epoch 1. Available variables are: ``epoch``, ``iteration``,
+            and ``split``.
+        mode (str): Mode to open the file in. Defaults to ``"w"`` (write mode).
+        sep (str): Separator for different examples. Defaults to new line
+            (``"\n"``).
+
+    Keyword Args:
+        pred_name (str): Name of the predicted value. This will be used as the
+            key to the dictionary returned by the model.
+    """
+    requires_pred = True
+    requires_label = False
+
+    def __init__(self, file_path: Union[str, Path], mode: str = "w",
+                 sep: str = "\n", *, pred_name: str):
+        super().__init__(pred_name=pred_name, label_name=None)
+        self.file_path = file_path
+        self.mode = mode
+        self.sep = sep
+
+    def _value(self) -> None:
+        pass
+
+    def finalize(self, executor) -> None:
+        path = str(self.file_path)
+        for key in ["epoch", "iteration", "split"]:
+            if "{" + key + "}" in path:
+                path = path.replace("{" + key + "}", str(executor.status[key]))
+        with open(path, self.mode) as writer:
+            writer.write(self.sep.join(str(p) for p in self.predicted))

--- a/texar/torch/run/metric/io.py
+++ b/texar/torch/run/metric/io.py
@@ -15,10 +15,9 @@
 Executor metrics that are actually not metrics, but for IO.
 """
 from pathlib import Path
-from typing import TypeVar, Sequence, Union
+from typing import TypeVar, Union
 
 from texar.torch.run.metric.base_metric import SimpleMetric
-from texar.torch.utils.types import PathLike
 
 __all__ = [
     "FileWriterMetric",


### PR DESCRIPTION
1. **File handling**
   Now in `Executor`, files are only opened in `train` and `test` and closed afterwards. Originally files were opened at the point of construction, and closed only when the program exits, using an `atexit` hook. This keeps the `Executor` object alive and creates a memory leak.

   Here we keep the change, but handles the logic more carefully. A few corner cases were also considered, and we also open files in `write_log`. This allows writing logs after construction and before training, while the original implementation simply does nothing, which is confusing for users.

2. **Metrics not evaluated**
   When `Executor` uses a `SimpleMetric` that is not logged, the metric is simply not evaluated. This is problematic for metrics with side effects, e.g. `FileWriterMetric` used in the BERT examples. We now explicitly evaluate all metrics at the end of each epoch, and the end of validation and testing.