### PR TITLE
Fixing index error after close files and clear `_log_destination`

### DIFF
--- a/tests/run/executor_test.py
+++ b/tests/run/executor_test.py
@@ -178,6 +178,11 @@ class ExecutorTest(unittest.TestCase):
         self.assertTrue(path.exists())
         self.assertEqual(len(list(os.walk(path))), 1)
 
+        # At this point, `executor._files_opened` is True, which will run the
+        #  main steps in the `_open_files()` function, it can cause IndexError
+        #  prior to this bug fix.
+        executor.test()
+
 
 if __name__ == "__main__":
     test = ExecutorTest()

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -20,7 +20,8 @@ import random
 import re
 import sys
 import time
-from collections import OrderedDict, defaultdict  # pylint: disable=unused-import
+from collections import OrderedDict, \
+    defaultdict  # pylint: disable=unused-import
 from datetime import datetime
 from pathlib import Path
 from typing import (
@@ -1347,7 +1348,8 @@ class Executor:
                 assert executor.train_data is not None
                 try:
                     size = len(executor.train_data)
-                    executor._train_tracker.set_size(size)  # pylint: disable=protected-access
+                    executor._train_tracker.set_size(
+                        size)  # pylint: disable=protected-access
                 except TypeError:
                     pass
                 executor.remove_action()
@@ -1467,7 +1469,8 @@ class Executor:
             _register(points, log_fn)
 
         def _flush_log_hook(executor: 'Executor'):
-            executor._write_log("", skip_non_tty=True)  # pylint: disable=protected-access
+            executor._write_log("",
+                                skip_non_tty=True)  # pylint: disable=protected-access
 
         def _register_status_fn(update_event: Event, log_fn: LogFn):
             def status_fn(executor: 'Executor'):
@@ -1740,6 +1743,13 @@ class Executor:
             return False
 
         self._opened_files = []
+
+        if len(self._log_destination) == 0:
+            # Make sure we have a list of the right size to store the
+            #   destinations. This may be caused after calling `_close_files`.
+            self._log_destination: List[IO[str]] = [None] * len(  # type: ignore
+                self.log_destination)
+
         for idx, dest in enumerate(self.log_destination):
             if isinstance(dest, (str, Path)):
                 # Append to the logs to prevent accidentally overwriting
@@ -1747,6 +1757,8 @@ class Executor:
                 file = open(dest, "a")
                 self._opened_files.append(file)
                 self._log_destination[idx] = file
+            else:
+                self._log_destination.append(dest)
 
         if self._tbx_logging_dir is not None:
             try:

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -1744,13 +1744,6 @@ class Executor:
 
         self._opened_files = []
 
-        if len(self._log_destination) == 0:
-            # Make sure we have a list of the right size to store the
-            #   destinations. Sometimes, this list can be empty
-            #   after calling `_close_files`.
-            self._log_destination: List[IO[str]] = [None] * len(  # type: ignore
-                self.log_destination)
-
         for idx, dest in enumerate(self.log_destination):
             if isinstance(dest, (str, Path)):
                 # Append to the logs to prevent accidentally overwriting
@@ -1783,7 +1776,6 @@ class Executor:
         for file in self._opened_files:
             file.close()
         self._opened_files = []
-        self._log_destination = []
 
         if self.summary_writer is not None:
             self.summary_writer.close()

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -1758,7 +1758,7 @@ class Executor:
                 self._opened_files.append(file)
                 self._log_destination[idx] = file
             else:
-                self._log_destination.append(dest)
+                self._log_destination[idx] = dest
 
         if self._tbx_logging_dir is not None:
             try:

--- a/texar/torch/run/executor.py
+++ b/texar/torch/run/executor.py
@@ -20,8 +20,8 @@ import random
 import re
 import sys
 import time
-from collections import OrderedDict, \
-    defaultdict  # pylint: disable=unused-import
+from collections import (OrderedDict,  # pylint: disable=unused-import
+                         defaultdict)
 from datetime import datetime
 from pathlib import Path
 from typing import (
@@ -1347,9 +1347,9 @@ class Executor:
             def _try_get_data_size(executor: 'Executor'):
                 assert executor.train_data is not None
                 try:
+                    # pylint: disable=protected-access
                     size = len(executor.train_data)
-                    executor._train_tracker.set_size(
-                        size)  # pylint: disable=protected-access
+                    executor._train_tracker.set_size(size)
                 except TypeError:
                     pass
                 executor.remove_action()
@@ -1469,8 +1469,8 @@ class Executor:
             _register(points, log_fn)
 
         def _flush_log_hook(executor: 'Executor'):
-            executor._write_log("",
-                                skip_non_tty=True)  # pylint: disable=protected-access
+            # pylint: disable=protected-access
+            executor._write_log("", skip_non_tty=True)
 
         def _register_status_fn(update_event: Event, log_fn: LogFn):
             def status_fn(executor: 'Executor'):
@@ -1746,7 +1746,8 @@ class Executor:
 
         if len(self._log_destination) == 0:
             # Make sure we have a list of the right size to store the
-            #   destinations. This may be caused after calling `_close_files`.
+            #   destinations. Sometimes, this list can be empty
+            #   after calling `_close_files`.
             self._log_destination: List[IO[str]] = [None] * len(  # type: ignore
                 self.log_destination)
 


### PR DESCRIPTION
This PR fixes https://github.com/asyml/texar-pytorch/issues/322

## The fix
At the time of `_open_files`, we check whether the length of the destination is zero, and fill in the List if needed.

## The test
In the executor tests, we called `test` after `train` in all the tests. In this way, we ensure the `_files_opened` to have both `True` and `False` value, to allow us to test both branches in the `_open_files` function.
