### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
 
     install_requires=[
         'regex>=2018.01.10',
-        'numpy>=1.16.6',
+        'numpy>=1.16.6, <=1.19.5',
         'requests',
         'funcsigs',
         'sentencepiece>=0.1.96',

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@ setuptools.setup(
 
     install_requires=[
         'regex>=2018.01.10',
-        'numpy>=1.15.4, <=1.19.5',
+        'numpy>=1.16.6',
         'requests',
         'funcsigs',
-        'sentencepiece==0.1.91',
+        'sentencepiece>=0.1.96',
         'mypy_extensions',
         'packaging>=19.0'
     ],


### PR DESCRIPTION
This PR updates some package versions to support Python 3.9

Updated dependencies:
- `'numpy>=1.16.6, <=1.19.5'`
- `'sentencepiece>=0.1.96'`