### PR TITLE
Complete error message

### DIFF
--- a/texar/torch/hyperparams.py
+++ b/texar/torch/hyperparams.py
@@ -225,8 +225,8 @@ class HParams:
                     continue
                 raise ValueError(
                     "Unknown hyperparameter: %s. "
-		    "Only when allow_new_hparam is set to True and "
-		    "only hyperparameters named 'kwargs' can contain new "
+                    "Only when allow_new_hparam is set to True and "
+                    "only hyperparameters named 'kwargs' can contain new "
                     "entries undefined in default hyperparameters." % name)
 
             if value is None:

--- a/texar/torch/hyperparams.py
+++ b/texar/torch/hyperparams.py
@@ -224,8 +224,9 @@ class HParams:
                     parsed_hparams[name] = HParams._parse_value(value, name)
                     continue
                 raise ValueError(
-                    "Unknown hyperparameter: %s. Only hyperparameters "
-                    "named 'kwargs' hyperparameters can contain new "
+                    "Unknown hyperparameter: %s. "
+		    "Only when allow_new_hparam is set to True and "
+		    "only hyperparameters named 'kwargs' can contain new "
                     "entries undefined in default hyperparameters." % name)
 
             if value is None:


### PR DESCRIPTION
The previous error message is confusing.
Even though a user passes in `kwargs` , since `allow_new_hparam` is set to`False`, the error message will still say that `Only hyperparameters named 'kwargs' hyperparameters can contain new entries undefined in default hyperparameters.`